### PR TITLE
chore: add validation removing trailing / from api endpoint

### DIFF
--- a/orcasecurity/provider.go
+++ b/orcasecurity/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"terraform-provider-orcasecurity/orcasecurity/api_client"
 	"terraform-provider-orcasecurity/orcasecurity/automation"
 	"terraform-provider-orcasecurity/orcasecurity/business_unit"
@@ -133,6 +134,17 @@ func (p *orcasecurityProvider) Configure(ctx context.Context, req provider.Confi
 	if !config.APIToken.IsNull() {
 		api_token = config.APIToken.ValueString()
 	}
+
+	// Trim trailing slashes from the API endpoint
+	trimmedEndpoint := strings.TrimRight(api_endpoint, "/")
+	if trimmedEndpoint != api_endpoint {
+		tflog.Warn(ctx, "Trailing slash detected in 'api_endpoint'. It has been automatically removed.", map[string]interface{}{
+			"original": api_endpoint,
+			"trimmed":  trimmedEndpoint,
+		})
+	}
+
+	api_endpoint = trimmedEndpoint
 
 	if api_endpoint == "" {
 		resp.Diagnostics.AddAttributeError(


### PR DESCRIPTION
After having a little bother configuring the correct API endpoint and getting some confusing `404` errors - I ended up contacting Orca support, after a little digging and double checking, it turned out to be the trailing `/` in my provider config. 

One of the support engineers mentioned he lost quite a bit of time to chasing this down previously which is why he knew to check it.

Adding this should hopefully save other users some time in the future and save Orca support from spending any more time on this particular issue.

This change is minor and passes all tests locally.
When  a trailing `/` is removed, a warning entry is added to the terraform log for debug purposes. 