### PR TITLE
fix: Remove typo from account_tags_info_list

### DIFF
--- a/orcasecurity/api_client/business_unit.go
+++ b/orcasecurity/api_client/business_unit.go
@@ -13,7 +13,7 @@ type BusinessUnitFilter struct {
 	CloudProviders []string `json:"cloud_provider,omitempty"`
 	CustomTags     []string `json:"custom_tags,omitempty"`
 	CloudTags      []string `json:"inventory_tags,omitempty"`
-	AccountTags    []string `json:"accounts_tags_info_list,omitempty"`
+	AccountTags    []string `json:"account_tags_info_list,omitempty"`
 	CloudAccounts  []string `json:"cloud_vendor_id,omitempty"`
 }
 


### PR DESCRIPTION
Fixes typo in `BusinessUnitFilter` `AccountTags` field tag which prevents business unit creation from succeeding when attempting to specify resources with `cloud_account_tags` .

Fixes https://github.com/orcasecurity/terraform-provider-orcasecurity/issues/207