### PR TITLE
WASP-1126\add retry HTTP error 5xx on terraform provider

### DIFF
--- a/orcasecurity/api_client/api_client.go
+++ b/orcasecurity/api_client/api_client.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -94,33 +93,22 @@ func (c *APIClient) doRequest(req http.Request) (*APIResponse, error) {
 	// Log request details
 	fmt.Printf("Making request to: %s %s\n", req.Method, req.URL)
 
-	res, err := c.Execute(req)
+	resp, err := c.roundTripWithRetry(req)
 	if err != nil {
 		return nil, fmt.Errorf("request execution failed: %v", err)
 	}
-	defer res.Body.Close()
-
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %v", err)
-	}
 
 	// Log response details
-	fmt.Printf("Response Status: %d\n", res.StatusCode)
-	fmt.Printf("Response Body: %s\n", string(body))
+	fmt.Printf("Response Status: %d\n", resp.StatusCode())
+	fmt.Printf("Response Body: %s\n", string(resp.Body()))
 
-	response := APIResponse{
-		_body:    body,
-		response: res,
+	if !resp.IsOk() {
+		apiErr := resp.Error()
+		return resp, fmt.Errorf("API returned error - status: %d, body: %s, error: %v",
+			resp.StatusCode(), string(resp.Body()), apiErr)
 	}
 
-	if !response.IsOk() {
-		err := response.Error()
-		return &response, fmt.Errorf("API returned error - status: %d, body: %s, error: %v",
-			res.StatusCode, string(body), err)
-	}
-
-	return &response, nil
+	return resp, nil
 }
 
 // Execute GET HTTP request.

--- a/orcasecurity/api_client/api_client_retry.go
+++ b/orcasecurity/api_client/api_client_retry.go
@@ -1,0 +1,157 @@
+package api_client
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	maxHTTPRetryAttempts = 5
+	retryBaseDelay       = 250 * time.Millisecond
+	retryMaxDelay       = 16 * time.Second
+	retryAfterCap        = 2 * time.Minute
+)
+
+func isRetriableHTTPStatus(status int) bool {
+	switch status {
+	case http.StatusRequestTimeout, http.StatusTooManyRequests,
+		http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func isRetriableRoundTripError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var ne net.Error
+	if errors.As(err, &ne) {
+		if ne.Timeout() {
+			return true
+		}
+		if t, ok := ne.(interface{ Temporary() bool }); ok && t.Temporary() {
+			return true
+		}
+	}
+	return false
+}
+
+func retryDelay(attempt int, resp *http.Response) time.Duration {
+	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			if s, err := strconv.ParseInt(ra, 10, 64); err == nil && s > 0 {
+				d := time.Duration(s) * time.Second
+				if d > retryAfterCap {
+					d = retryAfterCap
+				}
+				return d
+			}
+		}
+	}
+	shift := attempt
+	if shift > 6 {
+		shift = 6
+	}
+	d := retryBaseDelay * time.Duration(1<<uint(shift))
+	if d > retryMaxDelay {
+		return retryMaxDelay
+	}
+	return d
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// roundTripWithRetry performs the HTTP round trip with retries for transient
+// transport failures and selected HTTP status codes (408, 429, 502, 503, 504).
+// On success (any HTTP status), returns a fully read APIResponse; err is only
+// for request body read failures, transport failures after retries, or context
+// cancellation during backoff.
+func (c *APIClient) roundTripWithRetry(req http.Request) (*APIResponse, error) {
+	ctx := req.Context()
+
+	var reqBody []byte
+	if req.Body != nil {
+		var err error
+		reqBody, err = io.ReadAll(req.Body)
+		req.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read request body: %w", err)
+		}
+	}
+
+	for attempt := 0; attempt < maxHTTPRetryAttempts; attempt++ {
+		r := req.Clone(ctx)
+		if reqBody != nil {
+			b := reqBody
+			r.Body = io.NopCloser(bytes.NewReader(b))
+			r.GetBody = func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(b)), nil
+			}
+			r.ContentLength = int64(len(b))
+		}
+
+		res, execErr := c.Execute(*r)
+		if execErr != nil {
+			if attempt < maxHTTPRetryAttempts-1 && isRetriableRoundTripError(execErr) {
+				if err := sleepCtx(ctx, retryDelay(attempt, nil)); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			return nil, execErr
+		}
+
+		body, readErr := io.ReadAll(res.Body)
+		res.Body.Close()
+		if readErr != nil {
+			if attempt < maxHTTPRetryAttempts-1 && isRetriableRoundTripError(readErr) {
+				if err := sleepCtx(ctx, retryDelay(attempt, nil)); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			return nil, readErr
+		}
+
+		apiResp := &APIResponse{_body: body, response: res}
+
+		if apiResp.IsOk() {
+			return apiResp, nil
+		}
+		if !isRetriableHTTPStatus(res.StatusCode) {
+			return apiResp, nil
+		}
+		if attempt == maxHTTPRetryAttempts-1 {
+			return apiResp, nil
+		}
+		if err := sleepCtx(ctx, retryDelay(attempt, res)); err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, errors.New("orca api client: retry loop exhausted")
+}

--- a/orcasecurity/api_client/api_client_retry.go
+++ b/orcasecurity/api_client/api_client_retry.go
@@ -15,7 +15,7 @@ import (
 const (
 	maxHTTPRetryAttempts = 5
 	retryBaseDelay       = 250 * time.Millisecond
-	retryMaxDelay       = 16 * time.Second
+	retryMaxDelay        = 16 * time.Second
 	retryAfterCap        = 2 * time.Minute
 )
 
@@ -78,6 +78,31 @@ func httpResponseFinalOrBackoff(ctx context.Context, attempt int, body []byte, r
 		return nil, false, err
 	}
 	return nil, true, nil
+}
+
+// transportPhaseOutcome maps Execute / body-read errors to either another attempt
+// (continueLoop) or a terminal error for the caller to return.
+func transportPhaseOutcome(ctx context.Context, attempt int, phaseErr error) (continueLoop bool, err error) {
+	retry, sleepErr := sleepIfRetriableTransportError(ctx, attempt, phaseErr)
+	if sleepErr != nil {
+		return false, sleepErr
+	}
+	if retry {
+		return true, nil
+	}
+	return false, phaseErr
+}
+
+// httpResponsePhaseOutcome maps HTTP status handling to continue, terminal error, or success.
+func httpResponsePhaseOutcome(ctx context.Context, attempt int, body []byte, res *http.Response) (apiResp *APIResponse, continueLoop bool, err error) {
+	apiResp, retry, sleepErr := httpResponseFinalOrBackoff(ctx, attempt, body, res)
+	if sleepErr != nil {
+		return nil, false, sleepErr
+	}
+	if retry {
+		return nil, true, nil
+	}
+	return apiResp, false, nil
 }
 
 func isRetriableHTTPStatus(status int) bool {
@@ -162,33 +187,27 @@ func (c *APIClient) roundTripWithRetry(req http.Request) (*APIResponse, error) {
 		r := cloneRequestWithBody(ctx, &req, reqBody)
 		res, execErr := c.Execute(r)
 		if execErr != nil {
-			retry, sleepErr := sleepIfRetriableTransportError(ctx, attempt, execErr)
-			if sleepErr != nil {
-				return nil, sleepErr
-			}
-			if retry {
+			cont, out := transportPhaseOutcome(ctx, attempt, execErr)
+			if cont {
 				continue
 			}
-			return nil, execErr
+			return nil, out
 		}
 
 		body, readErr := readResponseBody(res)
 		if readErr != nil {
-			retry, sleepErr := sleepIfRetriableTransportError(ctx, attempt, readErr)
-			if sleepErr != nil {
-				return nil, sleepErr
-			}
-			if retry {
+			cont, out := transportPhaseOutcome(ctx, attempt, readErr)
+			if cont {
 				continue
 			}
-			return nil, readErr
+			return nil, out
 		}
 
-		apiResp, retry, sleepErr := httpResponseFinalOrBackoff(ctx, attempt, body, res)
-		if sleepErr != nil {
-			return nil, sleepErr
+		apiResp, cont, out := httpResponsePhaseOutcome(ctx, attempt, body, res)
+		if out != nil {
+			return nil, out
 		}
-		if retry {
+		if cont {
 			continue
 		}
 		return apiResp, nil

--- a/orcasecurity/api_client/api_client_retry.go
+++ b/orcasecurity/api_client/api_client_retry.go
@@ -171,6 +171,39 @@ func sleepCtx(ctx context.Context, d time.Duration) error {
 	}
 }
 
+// roundTripIteration runs a single HTTP attempt (execute, read body, apply HTTP retry policy).
+// If tryAgain is true, the caller should run another attempt. If tryAgain is false and err is nil,
+// resp is the final APIResponse. If err is non-nil, the caller must return that error.
+func (c *APIClient) roundTripIteration(ctx context.Context, attempt int, proto *http.Request, reqBody []byte) (resp *APIResponse, tryAgain bool, err error) {
+	r := cloneRequestWithBody(ctx, proto, reqBody)
+	res, execErr := c.Execute(r)
+	if execErr != nil {
+		cont, out := transportPhaseOutcome(ctx, attempt, execErr)
+		if cont {
+			return nil, true, nil
+		}
+		return nil, false, out
+	}
+
+	body, readErr := readResponseBody(res)
+	if readErr != nil {
+		cont, out := transportPhaseOutcome(ctx, attempt, readErr)
+		if cont {
+			return nil, true, nil
+		}
+		return nil, false, out
+	}
+
+	apiResp, cont, out := httpResponsePhaseOutcome(ctx, attempt, body, res)
+	if out != nil {
+		return nil, false, out
+	}
+	if cont {
+		return nil, true, nil
+	}
+	return apiResp, false, nil
+}
+
 // roundTripWithRetry performs the HTTP round trip with retries for transient
 // transport failures and selected HTTP status codes (408, 429, 502, 503, 504).
 // On success (any HTTP status), returns a fully read APIResponse; err is only
@@ -184,33 +217,14 @@ func (c *APIClient) roundTripWithRetry(req http.Request) (*APIResponse, error) {
 	}
 
 	for attempt := 0; attempt < maxHTTPRetryAttempts; attempt++ {
-		r := cloneRequestWithBody(ctx, &req, reqBody)
-		res, execErr := c.Execute(r)
-		if execErr != nil {
-			cont, out := transportPhaseOutcome(ctx, attempt, execErr)
-			if cont {
-				continue
-			}
-			return nil, out
+		resp, tryAgain, iterErr := c.roundTripIteration(ctx, attempt, &req, reqBody)
+		if iterErr != nil {
+			return nil, iterErr
 		}
-
-		body, readErr := readResponseBody(res)
-		if readErr != nil {
-			cont, out := transportPhaseOutcome(ctx, attempt, readErr)
-			if cont {
-				continue
-			}
-			return nil, out
-		}
-
-		apiResp, cont, out := httpResponsePhaseOutcome(ctx, attempt, body, res)
-		if out != nil {
-			return nil, out
-		}
-		if cont {
+		if tryAgain {
 			continue
 		}
-		return apiResp, nil
+		return resp, nil
 	}
 
 	return nil, errors.New("orca api client: retry loop exhausted")

--- a/orcasecurity/api_client/api_client_retry.go
+++ b/orcasecurity/api_client/api_client_retry.go
@@ -19,6 +19,67 @@ const (
 	retryAfterCap        = 2 * time.Minute
 )
 
+func slurpRequestBody(req *http.Request) ([]byte, error) {
+	if req.Body == nil {
+		return nil, nil
+	}
+	reqBody, err := io.ReadAll(req.Body)
+	req.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("read request body: %w", err)
+	}
+	return reqBody, nil
+}
+
+func cloneRequestWithBody(ctx context.Context, proto *http.Request, reqBody []byte) http.Request {
+	r := proto.Clone(ctx)
+	if reqBody == nil {
+		return *r
+	}
+	b := reqBody
+	r.Body = io.NopCloser(bytes.NewReader(b))
+	r.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(b)), nil
+	}
+	r.ContentLength = int64(len(b))
+	return *r
+}
+
+func readResponseBody(res *http.Response) ([]byte, error) {
+	defer res.Body.Close()
+	return io.ReadAll(res.Body)
+}
+
+// sleepIfRetriableTransportError backs off when err is retriable and attempts remain.
+// Returns retry=true to run another attempt; retry=false with nil err to surface errOut;
+// or retry=false with non-nil err on context cancellation during sleep.
+func sleepIfRetriableTransportError(ctx context.Context, attempt int, errOut error) (retry bool, err error) {
+	if attempt >= maxHTTPRetryAttempts-1 || !isRetriableRoundTripError(errOut) {
+		return false, nil
+	}
+	if err := sleepCtx(ctx, retryDelay(attempt, nil)); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// httpResponseFinalOrBackoff returns the API response when the caller should stop (success,
+// non-retriable HTTP status, or last attempt). If retry is true, backoff was applied and
+// another attempt should run.
+func httpResponseFinalOrBackoff(ctx context.Context, attempt int, body []byte, res *http.Response) (apiResp *APIResponse, retry bool, err error) {
+	apiResp = &APIResponse{_body: body, response: res}
+	if apiResp.IsOk() {
+		return apiResp, false, nil
+	}
+	if !isRetriableHTTPStatus(res.StatusCode) || attempt == maxHTTPRetryAttempts-1 {
+		return apiResp, false, nil
+	}
+	if err := sleepCtx(ctx, retryDelay(attempt, res)); err != nil {
+		return nil, false, err
+	}
+	return nil, true, nil
+}
+
 func isRetriableHTTPStatus(status int) bool {
 	switch status {
 	case http.StatusRequestTimeout, http.StatusTooManyRequests,
@@ -92,65 +153,45 @@ func sleepCtx(ctx context.Context, d time.Duration) error {
 // cancellation during backoff.
 func (c *APIClient) roundTripWithRetry(req http.Request) (*APIResponse, error) {
 	ctx := req.Context()
-
-	var reqBody []byte
-	if req.Body != nil {
-		var err error
-		reqBody, err = io.ReadAll(req.Body)
-		req.Body.Close()
-		if err != nil {
-			return nil, fmt.Errorf("read request body: %w", err)
-		}
+	reqBody, err := slurpRequestBody(&req)
+	if err != nil {
+		return nil, err
 	}
 
 	for attempt := 0; attempt < maxHTTPRetryAttempts; attempt++ {
-		r := req.Clone(ctx)
-		if reqBody != nil {
-			b := reqBody
-			r.Body = io.NopCloser(bytes.NewReader(b))
-			r.GetBody = func() (io.ReadCloser, error) {
-				return io.NopCloser(bytes.NewReader(b)), nil
-			}
-			r.ContentLength = int64(len(b))
-		}
-
-		res, execErr := c.Execute(*r)
+		r := cloneRequestWithBody(ctx, &req, reqBody)
+		res, execErr := c.Execute(r)
 		if execErr != nil {
-			if attempt < maxHTTPRetryAttempts-1 && isRetriableRoundTripError(execErr) {
-				if err := sleepCtx(ctx, retryDelay(attempt, nil)); err != nil {
-					return nil, err
-				}
+			retry, sleepErr := sleepIfRetriableTransportError(ctx, attempt, execErr)
+			if sleepErr != nil {
+				return nil, sleepErr
+			}
+			if retry {
 				continue
 			}
 			return nil, execErr
 		}
 
-		body, readErr := io.ReadAll(res.Body)
-		res.Body.Close()
+		body, readErr := readResponseBody(res)
 		if readErr != nil {
-			if attempt < maxHTTPRetryAttempts-1 && isRetriableRoundTripError(readErr) {
-				if err := sleepCtx(ctx, retryDelay(attempt, nil)); err != nil {
-					return nil, err
-				}
+			retry, sleepErr := sleepIfRetriableTransportError(ctx, attempt, readErr)
+			if sleepErr != nil {
+				return nil, sleepErr
+			}
+			if retry {
 				continue
 			}
 			return nil, readErr
 		}
 
-		apiResp := &APIResponse{_body: body, response: res}
-
-		if apiResp.IsOk() {
-			return apiResp, nil
+		apiResp, retry, sleepErr := httpResponseFinalOrBackoff(ctx, attempt, body, res)
+		if sleepErr != nil {
+			return nil, sleepErr
 		}
-		if !isRetriableHTTPStatus(res.StatusCode) {
-			return apiResp, nil
+		if retry {
+			continue
 		}
-		if attempt == maxHTTPRetryAttempts-1 {
-			return apiResp, nil
-		}
-		if err := sleepCtx(ctx, retryDelay(attempt, res)); err != nil {
-			return nil, err
-		}
+		return apiResp, nil
 	}
 
 	return nil, errors.New("orca api client: retry loop exhausted")

--- a/orcasecurity/api_client/api_client_retry_test.go
+++ b/orcasecurity/api_client/api_client_retry_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	retryTestAPIEndpoint = "http://localhost"
+	retryTestAPIEndpoint  = "http://localhost"
 	errFmtRetryTestStatus = "status = %d"
 )
 

--- a/orcasecurity/api_client/api_client_retry_test.go
+++ b/orcasecurity/api_client/api_client_retry_test.go
@@ -7,6 +7,11 @@ import (
 	"testing"
 )
 
+const (
+	retryTestAPIEndpoint = "http://localhost"
+	errFmtRetryTestStatus = "status = %d"
+)
+
 func TestIsRetriableHTTPStatus(t *testing.T) {
 	tests := []struct {
 		code int
@@ -49,11 +54,11 @@ func TestRoundTripWithRetry_502Then200(t *testing.T) {
 	})}
 
 	c := &APIClient{
-		APIEndpoint: "http://localhost",
+		APIEndpoint: retryTestAPIEndpoint,
 		APIToken:    "secret",
 		HTTPClient:  httpClient,
 	}
-	req, err := http.NewRequest(http.MethodGet, "http://localhost/api/x", nil)
+	req, err := http.NewRequest(http.MethodGet, retryTestAPIEndpoint+"/api/x", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +70,7 @@ func TestRoundTripWithRetry_502Then200(t *testing.T) {
 		t.Fatalf("expected 3 HTTP attempts, got %d", n)
 	}
 	if resp.StatusCode() != http.StatusOK {
-		t.Fatalf("status = %d", resp.StatusCode())
+		t.Fatalf(errFmtRetryTestStatus, resp.StatusCode())
 	}
 }
 
@@ -81,8 +86,8 @@ func TestRoundTripWithRetry_NoRetryOn400(t *testing.T) {
 		}
 	})}
 
-	c := &APIClient{APIEndpoint: "http://localhost", APIToken: "secret", HTTPClient: httpClient}
-	req, _ := http.NewRequest(http.MethodGet, "http://localhost/", nil)
+	c := &APIClient{APIEndpoint: retryTestAPIEndpoint, APIToken: "secret", HTTPClient: httpClient}
+	req, _ := http.NewRequest(http.MethodGet, retryTestAPIEndpoint+"/", nil)
 	resp, err := c.roundTripWithRetry(*req)
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +96,7 @@ func TestRoundTripWithRetry_NoRetryOn400(t *testing.T) {
 		t.Fatalf("expected 1 attempt, got %d", n)
 	}
 	if resp.StatusCode() != http.StatusBadRequest {
-		t.Fatalf("status = %d", resp.StatusCode())
+		t.Fatalf(errFmtRetryTestStatus, resp.StatusCode())
 	}
 }
 
@@ -121,8 +126,8 @@ func TestRoundTripWithRetry_POSTBodyPreservedAcrossRetries(t *testing.T) {
 		}
 	})}
 
-	c := &APIClient{APIEndpoint: "http://localhost", APIToken: "secret", HTTPClient: httpClient}
-	req, _ := http.NewRequest(http.MethodPost, "http://localhost/r", strings.NewReader(wantBody))
+	c := &APIClient{APIEndpoint: retryTestAPIEndpoint, APIToken: "secret", HTTPClient: httpClient}
+	req, _ := http.NewRequest(http.MethodPost, retryTestAPIEndpoint+"/r", strings.NewReader(wantBody))
 	resp, err := c.roundTripWithRetry(*req)
 	if err != nil {
 		t.Fatal(err)
@@ -131,6 +136,6 @@ func TestRoundTripWithRetry_POSTBodyPreservedAcrossRetries(t *testing.T) {
 		t.Fatalf("attempts = %d", n)
 	}
 	if resp.StatusCode() != http.StatusOK {
-		t.Fatalf("status = %d", resp.StatusCode())
+		t.Fatalf(errFmtRetryTestStatus, resp.StatusCode())
 	}
 }

--- a/orcasecurity/api_client/api_client_retry_test.go
+++ b/orcasecurity/api_client/api_client_retry_test.go
@@ -1,0 +1,136 @@
+package api_client
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestIsRetriableHTTPStatus(t *testing.T) {
+	tests := []struct {
+		code int
+		want bool
+	}{
+		{http.StatusBadGateway, true},
+		{http.StatusServiceUnavailable, true},
+		{http.StatusGatewayTimeout, true},
+		{http.StatusTooManyRequests, true},
+		{http.StatusRequestTimeout, true},
+		{http.StatusBadRequest, false},
+		{http.StatusNotFound, false},
+		{http.StatusInternalServerError, false},
+	}
+	for _, tt := range tests {
+		if got := isRetriableHTTPStatus(tt.code); got != tt.want {
+			t.Errorf("isRetriableHTTPStatus(%d) = %v, want %v", tt.code, got, tt.want)
+		}
+	}
+}
+
+func TestRoundTripWithRetry_502Then200(t *testing.T) {
+	var n int
+	httpClient := &http.Client{Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+		n++
+		if n < 3 {
+			return &http.Response{
+				StatusCode: http.StatusBadGateway,
+				Body:       io.NopCloser(strings.NewReader(`<html>502</html>`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}
+	})}
+
+	c := &APIClient{
+		APIEndpoint: "http://localhost",
+		APIToken:    "secret",
+		HTTPClient:  httpClient,
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://localhost/api/x", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := c.roundTripWithRetry(*req)
+	if err != nil {
+		t.Fatalf("roundTripWithRetry: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("expected 3 HTTP attempts, got %d", n)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode())
+	}
+}
+
+func TestRoundTripWithRetry_NoRetryOn400(t *testing.T) {
+	var n int
+	httpClient := &http.Client{Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+		n++
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"no"}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}
+	})}
+
+	c := &APIClient{APIEndpoint: "http://localhost", APIToken: "secret", HTTPClient: httpClient}
+	req, _ := http.NewRequest(http.MethodGet, "http://localhost/", nil)
+	resp, err := c.roundTripWithRetry(*req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 attempt, got %d", n)
+	}
+	if resp.StatusCode() != http.StatusBadRequest {
+		t.Fatalf("status = %d", resp.StatusCode())
+	}
+}
+
+func TestRoundTripWithRetry_POSTBodyPreservedAcrossRetries(t *testing.T) {
+	var n int
+	wantBody := `{"a":1}`
+	httpClient := &http.Client{Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+		b, _ := io.ReadAll(req.Body)
+		_ = req.Body.Close()
+		if string(b) != wantBody {
+			t.Errorf("attempt %d: body = %q", n, string(b))
+		}
+		n++
+		if n == 1 {
+			return &http.Response{
+				StatusCode: http.StatusBadGateway,
+				Body:       io.NopCloser(strings.NewReader(`err`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}
+	})}
+
+	c := &APIClient{APIEndpoint: "http://localhost", APIToken: "secret", HTTPClient: httpClient}
+	req, _ := http.NewRequest(http.MethodPost, "http://localhost/r", strings.NewReader(wantBody))
+	resp, err := c.roundTripWithRetry(*req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("attempts = %d", n)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode())
+	}
+}

--- a/orcasecurity/api_client/custom_discovery_alert.go
+++ b/orcasecurity/api_client/custom_discovery_alert.go
@@ -177,16 +177,16 @@ func (client *APIClient) DeleteCustomRemediationText(data CustomDiscoveryAlertRe
 		return err
 	}
 
-	resp, err := client.Execute(*req)
+	resp, err := client.roundTripWithRetry(*req)
 	if err != nil {
 		return err
 	}
 
-	if resp.StatusCode == 404 {
+	if resp.StatusCode() == 404 {
 		return nil
 	}
 
-	if resp.StatusCode != 200 {
+	if !resp.IsOk() {
 		return fmt.Errorf("operation failed")
 	}
 

--- a/orcasecurity/api_client/custom_sonar_alert.go
+++ b/orcasecurity/api_client/custom_sonar_alert.go
@@ -180,16 +180,16 @@ func (client *APIClient) DeleteCustomSonarAlertRemediationText(data CustomSonarA
 		return err
 	}
 
-	resp, err := client.Execute(*req)
+	resp, err := client.roundTripWithRetry(*req)
 	if err != nil {
 		return err
 	}
 
-	if resp.StatusCode == 404 {
+	if resp.StatusCode() == 404 {
 		return nil
 	}
 
-	if resp.StatusCode != 200 {
+	if !resp.IsOk() {
 		return fmt.Errorf("operation failed")
 	}
 


### PR DESCRIPTION
## `roundTripWithRetry` (`api_client_retry.go`)

Orchestrates retries around the shared HTTP client:

- **Attempts:** up to **5** per logical call  
- **Backoff:** exponential, base **250ms**, capped at **16s** per wait  
- **Retriable HTTP statuses:** **408**, **429**, **502**, **503**, **504**  
- **500:** **not** retried (many app errors look like **500**; retries can duplicate side effects on non-idempotent calls)  
- **429:** honors **`Retry-After`** when it is a positive integer (**seconds**), capped at **2 minutes**  
- **Transport errors:** retries on timeouts, **`Temporary()`** network errors, and **`io.ErrUnexpectedEOF`** (see **`isRetriableRoundTripError`**)  
- **Request body:** read once up front and **replayed** on each attempt so **POST** / **PUT** / **DELETE** with a body stay valid across retries  
- **Context:** backoff uses **`req.Context()`**; if the context is cancelled, waiting stops and the error propagates  

### Implementation shape (maintainability / Sonar)

- **`roundTripIteration`:** one attempt — clone request + body, **`Execute`**, transport handling, read response body, HTTP retry policy (**`httpResponsePhaseOutcome`**). Returns **`(resp, tryAgain, err)`** so the outer loop stays simple.  
- **`roundTripWithRetry`:** slurp body → loop **`roundTripIteration`** → return final response or error.  
- **Helpers** (e.g. **`transportPhaseOutcome`**, **`httpResponsePhaseOutcome`**, **`sleepIfRetriableTransportError`**, **`httpResponseFinalOrBackoff`**, **`cloneRequestWithBody`**, …) keep per-function cognitive complexity within limits.  

## `doRequest` (`api_client.go`)

All **`Get`**, **`Head`**, **`Post`**, **`Put`**, and **`Delete`** paths go through **`roundTripWithRetry`** before the existing success / API error formatting.

## Sonar / discovery remediation **DELETE**

**`DeleteCustomSonarAlertRemediationText`** and **`DeleteCustomRemediationText`** used to call **`Execute`** directly so **404** could be treated as success (bypassing **`doRequest`**, which treats non-2xx as errors). They now use **`roundTripWithRetry`** with the same intent:

- **404** → success (no error)  
- Any other non-success → **`operation failed`** (via **`!resp.IsOk()`** — any **2xx** counts as success, not only **200**)  

**`SetCustomSonarAlertRemediationText`** / **`SetCustomRemediationText`** are unchanged structurally; they still use **`Put`** / **`Post`** → **`doRequest`**, so they pick up the same retry behavior automatically.

## Tests (`api_client_retry_test.go`)

- **`TestIsRetriableHTTPStatus`** — table of retriable vs non-retriable status codes  
- **`TestRoundTripWithRetry_502Then200`** — several failures then success; asserts attempt count  
- **`TestRoundTripWithRetry_NoRetryOn400`** — single attempt on client error  
- **`TestRoundTripWithRetry_POSTBodyPreservedAcrossRetries`** — identical body on each attempt after a retry  
- **Constants** — **`retryTestAPIEndpoint`**, **`errFmtRetryTestStatus`** (and related formatting) to avoid duplicated string literals for linters  