### PR TITLE
ci: golangci-lint v2 + action v9 for Go 1.25

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,9 +47,10 @@ jobs:
             - run: go mod download
 
             - name: Run linters
-              uses: golangci/golangci-lint-action@v6
+              uses: golangci/golangci-lint-action@v9
               with:
-                  version: latest
+                  # Must be built with Go >= module version (go 1.25+). See https://github.com/golangci/golangci-lint/releases
+                  version: v2.11.4
 
     generate:
         name: Generate artifacts

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,35 +1,38 @@
+# golangci-lint v2 schema (requires golangci-lint >= v2.4, built with Go >= 1.25 for go 1.25 modules)
+version: "2"
+
 run:
     timeout: 60m
 
 issues:
     max-issues-per-linter: 0
     max-same-issues: 0
-    exclude-rules:
-        #TODO: Enable failing gosimple checks
-        - linters:
-              - gosimple
-          text: "S(1007|1034|1039)"
-        # TODO: Enable failing staticchecks
-        - linters:
-              - staticcheck
-          text: "SA(1006|1019|4006|6005):"
 
-linters:
-    disable-all: true
+formatters:
     enable:
         - gofmt
         - goimports
+
+linters:
+    default: none
+    enable:
         - govet
-        - typecheck
         - unconvert
         - staticcheck
-        - gosimple
         - errcheck
         - ineffassign
         - unused
-
-linters-settings:
-    errcheck:
-        exclude-functions: ["github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set,fmt:.*,io:Close"]
-    nakedret:
-        max-func-lines: 40
+    exclusions:
+        rules:
+            # TODO: Enable failing gosimple checks (now part of staticcheck)
+            - linters:
+                  - staticcheck
+              text: "S(1007|1034|1039)"
+            # TODO: Enable failing staticchecks
+            - linters:
+                  - staticcheck
+              text: "SA(1006|1019|4006|6005):"
+    settings:
+        errcheck:
+            exclude-functions:
+                - "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set,fmt:.*,io:Close"

--- a/orcasecurity/api_client/api_client_retry.go
+++ b/orcasecurity/api_client/api_client_retry.go
@@ -24,7 +24,7 @@ func slurpRequestBody(req *http.Request) ([]byte, error) {
 		return nil, nil
 	}
 	reqBody, err := io.ReadAll(req.Body)
-	req.Body.Close()
+	_ = req.Body.Close()
 	if err != nil {
 		return nil, fmt.Errorf("read request body: %w", err)
 	}
@@ -46,7 +46,7 @@ func cloneRequestWithBody(ctx context.Context, proto *http.Request, reqBody []by
 }
 
 func readResponseBody(res *http.Response) ([]byte, error) {
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	return io.ReadAll(res.Body)
 }
 


### PR DESCRIPTION
## Problem

Lint CI fails when `go.mod` targets Go 1.25: the installed golangci-lint binary was built with Go 1.24 and refuses to load the config (`targeted Go version (1.25.0)`). Using `golangci/golangci-lint-action@v6` with `version: latest` also surfaced Node.js 20 deprecation warnings.

## Changes

- **Workflow**: `golangci/golangci-lint-action@v6` → **`@v9`**, pin **golangci-lint `v2.11.4`** (Go 1.25+ compatible binary).
- **Config**: migrate `.golangci.yml` to **golangci-lint v2** format (`version: "2"`, formatters for gofmt/goimports, `linters.default: none`, exclusions/settings layout).
- **Code**: satisfy **errcheck** for `Close()` in `api_client_retry.go`.

## Verification

- `golangci-lint run ./...` (v2.11.4): clean
- `go test ./...`: pass
