### PR TITLE
feat(automation_v2): support apply_on_existing flag at creation

### DIFF
--- a/docs/resources/automation_v2.md
+++ b/docs/resources/automation_v2.md
@@ -486,6 +486,7 @@ resource "orcasecurity_automation_v2" "analytics_integration" {
 ### Optional
 
 - `alert_dismissal_details` (Attributes) Details regarding dismissed alerts. (see [below for nested schema](#nestedatt--alert_dismissal_details))
+- `apply_on_existing` (Boolean) If true, the automation is applied retroactively to historical alerts at creation time via the `apply_on_existing=true` query parameter on POST. The flag is honored only at creation; changing the value forces resource replacement.
 - `alert_score_decrease_details` (Attributes) Details regarding decreasing the score for the selected alerts. (see [below for nested schema](#nestedatt--alert_score_decrease_details))
 - `alert_score_increase_details` (Attributes) Details regarding increasing the score for the selected alerts. (see [below for nested schema](#nestedatt--alert_score_increase_details))
 - `alert_score_specify_details` (Attributes) Details regarding specifying a new score for the selected alerts. (see [below for nested schema](#nestedatt--alert_score_specify_details))

--- a/orcasecurity/api_client/automation_v2.go
+++ b/orcasecurity/api_client/automation_v2.go
@@ -63,8 +63,12 @@ func (client *APIClient) DoesAutomationV2Exist(id string) (bool, error) {
 	return resp.StatusCode() == 200, nil
 }
 
-func (client *APIClient) CreateAutomationV2(automation AutomationV2) (*AutomationV2, error) {
-	resp, err := client.Post("/api/automations", automation)
+func (client *APIClient) CreateAutomationV2(automation AutomationV2, applyOnExisting bool) (*AutomationV2, error) {
+	path := "/api/automations"
+	if applyOnExisting {
+		path += "?apply_on_existing=true"
+	}
+	resp, err := client.Post(path, automation)
 	if err != nil {
 		return nil, err
 	}

--- a/orcasecurity/api_client/automation_v2_test.go
+++ b/orcasecurity/api_client/automation_v2_test.go
@@ -211,7 +211,7 @@ func TestAutomationsV2_CreateAutomationV2(t *testing.T) {
 	})}
 
 	apiClient := api_client.APIClient{APIEndpoint: "http://localhost", APIToken: "secret", HTTPClient: httpClient}
-	automation, err := apiClient.CreateAutomationV2(expectedRequest)
+	automation, err := apiClient.CreateAutomationV2(expectedRequest, false)
 	if err != nil {
 		t.Fatalf("CreateAutomationV2 failed: %v", err)
 	}
@@ -225,6 +225,51 @@ func TestAutomationsV2_CreateAutomationV2(t *testing.T) {
 	}
 	if automation.Name != "New Automation" {
 		t.Errorf("Expected name 'New Automation', got '%s'", automation.Name)
+	}
+}
+
+func TestAutomationsV2_CreateAutomationV2_ApplyOnExisting(t *testing.T) {
+	expectedRequest := api_client.AutomationV2{
+		Name:   "Retro Automation",
+		Status: "enabled",
+		Filter: api_client.AutomationV2Filter{
+			SonarQuery: api_client.AutomationV2SonarQuery{
+				Models: []string{"Alert"},
+				Type:   "object_set",
+			},
+		},
+	}
+
+	mockResponse := `{
+		"status": "success",
+		"data": {
+			"id": "created-id-789",
+			"name": "Retro Automation",
+			"status": "enabled",
+			"filter": {"sonar_query": {"models": ["Alert"], "type": "object_set"}},
+			"actions": []
+		}
+	}`
+
+	var capturedQuery string
+	httpClient := &http.Client{Transport: api_client.RoundTripFunc(func(req *http.Request) *http.Response {
+		if req.URL.Path != "/api/automations" {
+			t.Errorf("Expected URL path /api/automations, got %s", req.URL.Path)
+		}
+		capturedQuery = req.URL.RawQuery
+		return &http.Response{
+			StatusCode: 201,
+			Body:       ioutil.NopCloser(strings.NewReader(mockResponse)),
+			Request:    req,
+		}
+	})}
+
+	apiClient := api_client.APIClient{APIEndpoint: "http://localhost", APIToken: "secret", HTTPClient: httpClient}
+	if _, err := apiClient.CreateAutomationV2(expectedRequest, true); err != nil {
+		t.Fatalf("CreateAutomationV2 failed: %v", err)
+	}
+	if capturedQuery != "apply_on_existing=true" {
+		t.Errorf("Expected query 'apply_on_existing=true', got %q", capturedQuery)
 	}
 }
 

--- a/orcasecurity/automation_v2/resource.go
+++ b/orcasecurity/automation_v2/resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -82,13 +83,14 @@ type automationV2SnoozeTemplateModel struct {
 }
 
 type automationV2ResourceModel struct {
-	ID            types.String             `tfsdk:"id"`
-	Name          types.String             `tfsdk:"name"`
-	BusinessUnits types.List               `tfsdk:"business_units"`
-	Description   types.String             `tfsdk:"description"`
-	Status        types.String             `tfsdk:"status"`
-	Filter        *automationV2FilterModel `tfsdk:"filter"`
-	EndTime       types.String             `tfsdk:"end_time"`
+	ID              types.String             `tfsdk:"id"`
+	Name            types.String             `tfsdk:"name"`
+	BusinessUnits   types.List               `tfsdk:"business_units"`
+	Description     types.String             `tfsdk:"description"`
+	Status          types.String             `tfsdk:"status"`
+	Filter          *automationV2FilterModel `tfsdk:"filter"`
+	EndTime         types.String             `tfsdk:"end_time"`
+	ApplyOnExisting types.Bool               `tfsdk:"apply_on_existing"`
 
 	AlertDismissalTemplate     *automationV2AlertDismissalTemplateModel     `tfsdk:"alert_dismissal_details"`
 	AlertScoreIncreaseTemplate *automationV2AlertScoreIncreaseTemplateModel `tfsdk:"alert_score_increase_details"`
@@ -290,6 +292,15 @@ func (r *automationV2Resource) Schema(_ context.Context, req resource.SchemaRequ
 			"end_time": schema.StringAttribute{
 				Description: "End time for the automation (ISO 8601 format). If specified, the automation will automatically disable after this time.",
 				Optional:    true,
+			},
+			"apply_on_existing": schema.BoolAttribute{
+				Description: "If true, the automation is applied retroactively to historical alerts at creation time via the `apply_on_existing=true` query parameter on POST. The flag is honored only at creation; changing the value forces resource replacement.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+					boolplanmodifier.RequiresReplace(),
+				},
 			},
 			"filter": schema.SingleNestedAttribute{
 				Description: "The filter that selects the alerts this automation applies to using sonar_query.",
@@ -877,7 +888,13 @@ func (r *automationV2Resource) Create(ctx context.Context, req resource.CreateRe
 		createReq.EndTime = plan.EndTime.ValueString()
 	}
 
-	instance, err := r.apiClient.CreateAutomationV2(createReq)
+	applyOnExisting := false
+	if !plan.ApplyOnExisting.IsNull() && !plan.ApplyOnExisting.IsUnknown() {
+		applyOnExisting = plan.ApplyOnExisting.ValueBool()
+	}
+	plan.ApplyOnExisting = types.BoolValue(applyOnExisting)
+
+	instance, err := r.apiClient.CreateAutomationV2(createReq, applyOnExisting)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Automation V2",

--- a/orcasecurity/automation_v2/resource.go
+++ b/orcasecurity/automation_v2/resource.go
@@ -888,10 +888,7 @@ func (r *automationV2Resource) Create(ctx context.Context, req resource.CreateRe
 		createReq.EndTime = plan.EndTime.ValueString()
 	}
 
-	applyOnExisting := false
-	if !plan.ApplyOnExisting.IsNull() && !plan.ApplyOnExisting.IsUnknown() {
-		applyOnExisting = plan.ApplyOnExisting.ValueBool()
-	}
+	applyOnExisting := plan.ApplyOnExisting.ValueBool()
 	plan.ApplyOnExisting = types.BoolValue(applyOnExisting)
 
 	instance, err := r.apiClient.CreateAutomationV2(createReq, applyOnExisting)

--- a/templates/resources/automation_v2.md.tmpl
+++ b/templates/resources/automation_v2.md.tmpl
@@ -30,6 +30,7 @@ Provides an automation. You can read more about automations [here](https://docs.
 ### Optional
 
 - `alert_dismissal_details` (Attributes) Details regarding dismissed alerts. (see [below for nested schema](#nestedatt--alert_dismissal_details))
+- `apply_on_existing` (Boolean) If true, the automation is applied retroactively to historical alerts at creation time via the `apply_on_existing=true` query parameter on POST. The flag is honored only at creation; changing the value forces resource replacement.
 - `alert_score_decrease_details` (Attributes) Details regarding decreasing the score for the selected alerts. (see [below for nested schema](#nestedatt--alert_score_decrease_details))
 - `alert_score_increase_details` (Attributes) Details regarding increasing the score for the selected alerts. (see [below for nested schema](#nestedatt--alert_score_increase_details))
 - `alert_score_specify_details` (Attributes) Details regarding specifying a new score for the selected alerts. (see [below for nested schema](#nestedatt--alert_score_specify_details))


### PR DESCRIPTION
## Summary

Adds a new optional `apply_on_existing` boolean attribute to the `orcasecurity_automation_v2` resource. When set to `true`, the provider appends `?apply_on_existing=true` to the `POST /api/automations` request at creation time, instructing the Orca API to retroactively apply the automation's actions (dismissal, score adjustment, snooze, etc.) to the existing alert set that matches the configured filter.

This mirrors the behavior already available in the Orca UI ("Apply on existing alerts" checkbox) and via the raw API. Previously, users who wanted retroactive application had to create the automation through the UI or with `curl`, then `terraform import` it — defeating the purpose of declarative management.

## Behavior

- `apply_on_existing` is **only** honored at POST. The underlying API has no equivalent on PUT.
- Changing the value on an existing resource therefore forces replacement (``RequiresReplace`` plan modifier). This is intentional: the new value would otherwise be silently ignored.
- The attribute defaults to ``false`` when omitted, preserving prior behavior for all existing configurations.
- ``UseStateForUnknown`` keeps the value stable across plans so already-managed resources don't show drift after upgrading.

## Example

```hcl
resource "orcasecurity_automation_v2" "lower_score_for_known_low_risk" {
  name              = "Lower score for known low-risk alert type"
  status            = "enabled"
  apply_on_existing = true

  filter = {
    sonar_query = jsonencode({
      models = ["Alert"]
      type   = "object_set"
      with = {
        type     = "operation"
        operator = "and"
        values = [
          { key = "Status",    type = "str", operator = "in", values = ["open", "in_progress"] },
          { key = "AlertType", type = "str", operator = "in", values = ["Git Ignore File (.gitignore) Missing in Repository"] },
        ]
      }
    })
  }

  alert_score_specify_details = {
    new_score = 1
    reason    = "Organization Preferences"
  }
}
```

## Changes

- ``orcasecurity/api_client/automation_v2.go``: ``CreateAutomationV2`` now takes an ``applyOnExisting bool`` parameter; appends query string when true.
- ``orcasecurity/automation_v2/resource.go``: new schema attribute (``Optional`` + ``Computed``) with ``UseStateForUnknown`` and ``RequiresReplace`` plan modifiers; ``Create`` reads the plan value and forwards it to the API client, defaulting to ``false`` when null.
- ``orcasecurity/api_client/automation_v2_test.go``: added ``TestAutomationsV2_CreateAutomationV2_ApplyOnExisting`` asserting the query string is set on POST; updated the existing create test to pass ``false`` for the new parameter.
- ``docs/resources/automation_v2.md`` + ``templates/resources/automation_v2.md.tmpl``: documented the new attribute.

## Test plan

- [x] ``go build ./...`` clean
- [x] ``go test ./...`` all packages pass (including new query-string assertion)
- [x] End-to-end test against EU tenant: created an automation with ``apply_on_existing = true`` for ``alert_score_specify_details { new_score = 1 }`` targeting a specific ``AlertType``; verified via Discovery search that pre-existing open alerts of that type now report ``OrcaScore = 1``, ``UserDefinedOrcaScore = 1``, and ``ScoreVector["User adjusted the Alert score"] = 1``.
- [x] Follow-up ``terraform plan`` is idempotent (no drift after apply).
- [x] Toggling the flag on an existing resource triggers ``RequiresReplace`` as expected.

## Backwards compatibility

The new attribute is optional and defaults to ``false``, so no existing configurations or state files are affected.