### PR TITLE
WASP-1262\(automation_v2): add apply_on_existing flag

### DIFF
--- a/docs/resources/automation_v2.md
+++ b/docs/resources/automation_v2.md
@@ -13,6 +13,33 @@ Provides an automation. You can read more about automations [here](https://docs.
 ## Example Usage
 
 ```terraform
+# Apply automation retroactively to existing alerts
+resource "orcasecurity_automation_v2" "reduce_risk_score" {
+  name              = "Reduce Risk Score"
+  description       = "Reduce risk score for open and in-progress alerts"
+  status            = "enabled"
+  apply_on_existing = true
+
+  filter = {
+    sonar_query = jsonencode({
+      models = ["Alert"]
+      type   = "object_set"
+      with = {
+        type     = "operation"
+        operator = "and"
+        values = [
+          { key = "Status", type = "str", operator = "in", values = ["open", "in_progress"] },
+        ]
+      }
+    })
+  }
+
+  alert_score_specify_details = {
+    new_score = 1
+    reason    = "Lower risk score"
+  }
+}
+
 # Basic automation v2 with Jira Cloud using external configuration
 resource "orcasecurity_automation_v2" "jira_cloud_basic" {
   name        = "Critical Alerts to Jira Cloud"
@@ -486,6 +513,7 @@ resource "orcasecurity_automation_v2" "analytics_integration" {
 ### Optional
 
 - `alert_dismissal_details` (Attributes) Details regarding dismissed alerts. (see [below for nested schema](#nestedatt--alert_dismissal_details))
+- `apply_on_existing` (Boolean) When true, retroactively applies the automation's actions to existing alerts matching the filter at creation time. Only honored on POST; changing this value forces resource replacement.
 - `alert_score_decrease_details` (Attributes) Details regarding decreasing the score for the selected alerts. (see [below for nested schema](#nestedatt--alert_score_decrease_details))
 - `alert_score_increase_details` (Attributes) Details regarding increasing the score for the selected alerts. (see [below for nested schema](#nestedatt--alert_score_increase_details))
 - `alert_score_specify_details` (Attributes) Details regarding specifying a new score for the selected alerts. (see [below for nested schema](#nestedatt--alert_score_specify_details))

--- a/examples/resources/automation_v2/example_1.tf
+++ b/examples/resources/automation_v2/example_1.tf
@@ -1,3 +1,30 @@
+# Apply automation retroactively to existing alerts
+resource "orcasecurity_automation_v2" "reduce_risk_score" {
+  name              = "Reduce Risk Score"
+  description       = "Reduce risk score for open and in-progress alerts"
+  status            = "enabled"
+  apply_on_existing = true
+
+  filter = {
+    sonar_query = jsonencode({
+      models = ["Alert"]
+      type   = "object_set"
+      with = {
+        type     = "operation"
+        operator = "and"
+        values = [
+          { key = "Status", type = "str", operator = "in", values = ["open", "in_progress"] },
+        ]
+      }
+    })
+  }
+
+  alert_score_specify_details = {
+    new_score = 1
+    reason    = "Lower risk score"
+  }
+}
+
 # Basic automation v2 with Jira Cloud using external configuration
 resource "orcasecurity_automation_v2" "jira_cloud_basic" {
   name        = "Critical Alerts to Jira Cloud"

--- a/orcasecurity/api_client/automation_v2.go
+++ b/orcasecurity/api_client/automation_v2.go
@@ -63,8 +63,12 @@ func (client *APIClient) DoesAutomationV2Exist(id string) (bool, error) {
 	return resp.StatusCode() == 200, nil
 }
 
-func (client *APIClient) CreateAutomationV2(automation AutomationV2) (*AutomationV2, error) {
-	resp, err := client.Post("/api/automations", automation)
+func (client *APIClient) CreateAutomationV2(automation AutomationV2, applyOnExisting bool) (*AutomationV2, error) {
+	path := "/api/automations"
+	if applyOnExisting {
+		path += "?apply_on_existing=true"
+	}
+	resp, err := client.Post(path, automation)
 	if err != nil {
 		return nil, err
 	}

--- a/orcasecurity/api_client/automation_v2_test.go
+++ b/orcasecurity/api_client/automation_v2_test.go
@@ -211,7 +211,7 @@ func TestAutomationsV2_CreateAutomationV2(t *testing.T) {
 	})}
 
 	apiClient := api_client.APIClient{APIEndpoint: "http://localhost", APIToken: "secret", HTTPClient: httpClient}
-	automation, err := apiClient.CreateAutomationV2(expectedRequest)
+	automation, err := apiClient.CreateAutomationV2(expectedRequest, false)
 	if err != nil {
 		t.Fatalf("CreateAutomationV2 failed: %v", err)
 	}
@@ -225,6 +225,61 @@ func TestAutomationsV2_CreateAutomationV2(t *testing.T) {
 	}
 	if automation.Name != "New Automation" {
 		t.Errorf("Expected name 'New Automation', got '%s'", automation.Name)
+	}
+}
+
+func TestAutomationsV2_CreateAutomationV2_ApplyOnExisting(t *testing.T) {
+	mockResponse := `{
+		"status": "success",
+		"data": {
+			"id": "created-id-789",
+			"name": "Existing Alerts Automation",
+			"status": "enabled",
+			"filter": {"sonar_query": {"models": ["Alert"], "type": "object_set"}},
+			"actions": []
+		}
+	}`
+
+	httpClient := &http.Client{Transport: api_client.RoundTripFunc(func(req *http.Request) *http.Response {
+		if req.Method != "POST" {
+			t.Errorf("Expected POST method, got %s", req.Method)
+		}
+		if req.URL.Path != "/api/automations" {
+			t.Errorf("Expected URL path /api/automations, got %s", req.URL.Path)
+		}
+		if req.URL.RawQuery != "apply_on_existing=true" {
+			t.Errorf("Expected query string 'apply_on_existing=true', got '%s'", req.URL.RawQuery)
+		}
+
+		return &http.Response{
+			StatusCode: 201,
+			Body:       ioutil.NopCloser(strings.NewReader(mockResponse)),
+			Request:    req,
+		}
+	})}
+
+	automation := api_client.AutomationV2{
+		Name:   "Existing Alerts Automation",
+		Status: "enabled",
+		Filter: api_client.AutomationV2Filter{
+			SonarQuery: api_client.AutomationV2SonarQuery{
+				Models: []string{"Alert"},
+				Type:   "object_set",
+			},
+		},
+		Actions: []api_client.AutomationV2Action{},
+	}
+
+	apiClient := api_client.APIClient{APIEndpoint: "http://localhost", APIToken: "secret", HTTPClient: httpClient}
+	result, err := apiClient.CreateAutomationV2(automation, true)
+	if err != nil {
+		t.Fatalf("CreateAutomationV2 with applyOnExisting=true failed: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Expected automation to be returned, got nil")
+	}
+	if result.ID != "created-id-789" {
+		t.Errorf("Expected ID 'created-id-789', got '%s'", result.ID)
 	}
 }
 

--- a/orcasecurity/automation_v2/resource.go
+++ b/orcasecurity/automation_v2/resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -131,7 +132,8 @@ type automationV2ResourceModel struct {
 	OpusTemplate                  *automationV2ExternalConfigTemplateModel `tfsdk:"opus_template"`
 	PantherTemplate               *automationV2ExternalConfigTemplateModel `tfsdk:"panther_template"`
 
-	OrganizationID types.String `tfsdk:"organization_id"`
+	OrganizationID   types.String `tfsdk:"organization_id"`
+	ApplyOnExisting  types.Bool   `tfsdk:"apply_on_existing"`
 }
 
 func NewAutomationV2Resource() resource.Resource {
@@ -261,6 +263,15 @@ func (r *automationV2Resource) Schema(_ context.Context, req resource.SchemaRequ
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"apply_on_existing": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "When true, retroactively applies the automation's actions to existing alerts matching the filter at creation time. Only honored on POST; changing this value forces resource replacement.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+					boolplanmodifier.RequiresReplace(),
 				},
 			},
 			"name": schema.StringAttribute{
@@ -877,7 +888,7 @@ func (r *automationV2Resource) Create(ctx context.Context, req resource.CreateRe
 		createReq.EndTime = plan.EndTime.ValueString()
 	}
 
-	instance, err := r.apiClient.CreateAutomationV2(createReq)
+	instance, err := r.apiClient.CreateAutomationV2(createReq, plan.ApplyOnExisting.ValueBool())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Automation V2",

--- a/orcasecurity/automation_v2/resource.go
+++ b/orcasecurity/automation_v2/resource.go
@@ -132,8 +132,8 @@ type automationV2ResourceModel struct {
 	OpusTemplate                  *automationV2ExternalConfigTemplateModel `tfsdk:"opus_template"`
 	PantherTemplate               *automationV2ExternalConfigTemplateModel `tfsdk:"panther_template"`
 
-	OrganizationID   types.String `tfsdk:"organization_id"`
-	ApplyOnExisting  types.Bool   `tfsdk:"apply_on_existing"`
+	OrganizationID  types.String `tfsdk:"organization_id"`
+	ApplyOnExisting types.Bool   `tfsdk:"apply_on_existing"`
 }
 
 func NewAutomationV2Resource() resource.Resource {

--- a/templates/resources/automation_v2.md.tmpl
+++ b/templates/resources/automation_v2.md.tmpl
@@ -30,6 +30,7 @@ Provides an automation. You can read more about automations [here](https://docs.
 ### Optional
 
 - `alert_dismissal_details` (Attributes) Details regarding dismissed alerts. (see [below for nested schema](#nestedatt--alert_dismissal_details))
+- `apply_on_existing` (Boolean) When true, retroactively applies the automation's actions to existing alerts matching the filter at creation time. Only honored on POST; changing this value forces resource replacement.
 - `alert_score_decrease_details` (Attributes) Details regarding decreasing the score for the selected alerts. (see [below for nested schema](#nestedatt--alert_score_decrease_details))
 - `alert_score_increase_details` (Attributes) Details regarding increasing the score for the selected alerts. (see [below for nested schema](#nestedatt--alert_score_increase_details))
 - `alert_score_specify_details` (Attributes) Details regarding specifying a new score for the selected alerts. (see [below for nested schema](#nestedatt--alert_score_specify_details))


### PR DESCRIPTION
- `orcasecurity/automation_v2/resource.go`: new schema attribute (`Optional`/`Computed`) with `UseStateForUnknown` + `RequiresReplace`; `Create` passes flag to API client
- `orcasecurity/api_client/automation_v2_test.go`: new `TestAutomationsV2_CreateAutomationV2_ApplyOnExisting` asserts query string on POST; existing create test updated
- `docs/resources/automation_v2.md` + `templates/resources/automation_v2.md.tmpl` + `examples/resources/automation_v2/example_1.tf`: documented and demonstrated

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all packages pass including new query-string assertion
- [x] `go generate ./...` docs regenerated cleanly
- [x] Toggling flag on existing resource triggers `RequiresReplace`
- [x] Omitting flag preserves prior behavior (defaults to `false`)

## Backwards compatibility

Optional attribute defaulting to `false` — no existing configurations affected.