### PR TITLE
WASP-1401/allow empty reason and justification in automation_v2

### DIFF
--- a/docs/resources/automation_v2.md
+++ b/docs/resources/automation_v2.md
@@ -572,8 +572,8 @@ Required:
 
 Optional:
 
-- `justification` (String) More detailed reasoning as to why these alerts are being dismissed.
-- `reason` (String) The reason these alerts are being dismissed.
+- `justification` (String) More detailed reasoning as to why these alerts are being dismissed. Optional; empty string is treated as omitted.
+- `reason` (String) The reason these alerts are being dismissed. Optional; empty string is treated as omitted.
 
 <a id="nestedatt--alert_score_decrease_details"></a>
 
@@ -581,8 +581,8 @@ Optional:
 
 Optional:
 
-- `justification` (String) More detailed reasoning as to why these alerts are having their score changed.
-- `reason` (String) The reason these alerts are having their score decreased.
+- `justification` (String) More detailed reasoning as to why these alerts are having their score changed. Optional; empty string is treated as omitted.
+- `reason` (String) The reason these alerts are having their score decreased. Optional; empty string is treated as omitted.
 
 <a id="nestedatt--alert_score_increase_details"></a>
 
@@ -590,8 +590,8 @@ Optional:
 
 Optional:
 
-- `justification` (String) More detailed reasoning as to why these alerts are having their score changed.
-- `reason` (String) The reason these alerts are having their score increased.
+- `justification` (String) More detailed reasoning as to why these alerts are having their score changed. Optional; empty string is treated as omitted.
+- `reason` (String) The reason these alerts are having their score increased. Optional; empty string is treated as omitted.
 
 <a id="nestedatt--alert_score_specify_details"></a>
 
@@ -603,8 +603,8 @@ Required:
 
 Optional:
 
-- `justification` (String) More detailed reasoning as to why these alerts are having their score changed.
-- `reason` (String) The reason these alerts are having their score changed.
+- `justification` (String) More detailed reasoning as to why these alerts are having their score changed. Optional; empty string is treated as omitted.
+- `reason` (String) The reason these alerts are having their score changed. Optional; empty string is treated as omitted.
 
 <a id="nestedatt--aws_security_hub_template"></a>
 
@@ -822,8 +822,8 @@ Required:
 
 Optional:
 
-- `justification` (String) Justification for snoozing.
-- `reason` (String) Reason for snoozing.
+- `justification` (String) Justification for snoozing. Optional; empty string is treated as omitted.
+- `reason` (String) Reason for snoozing. Optional; empty string is treated as omitted.
 
 <a id="nestedatt--snowflake_template"></a>
 

--- a/docs/resources/business_unit.md
+++ b/docs/resources/business_unit.md
@@ -58,8 +58,13 @@ resource "orcasecurity_business_unit" "BU-OrcaTags" {
 
 ### Optional
 
+- `application` (String) Application or product line the business unit represents.
+- `business_criticality` (String) Business criticality. Valid values: `low`, `medium`, `high`, `critical`.
+- `contact_emails` (List of String) Contact emails associated with the business unit.
+- `deployment_stages` (List of String) Deployment stages associated with the business unit. Up to 2 values.
 - `filter_data` (Attributes) The filter to select the resources of the business unit. If you are creating a BU that only includes Shift Left resources (projects), this can be safely excluded. (see [below for nested schema](#nestedatt--filter_data))
 - `global_filter` (Boolean) Whether or not this is a business unit all users within your Orca org can use. If set to true, then it is accessible to all other users in your org.
+- `owner_team` (String) Owning team or department for the business unit.
 - `shiftleft_filter_data` (Attributes) The filter to select Shift Left resources for the business unit. If you are creating a BU that only includes Shift Left resources (projects), this can be safely excluded. (see [below for nested schema](#nestedatt--shiftleft_filter_data))
 
 ### Read-Only

--- a/docs/resources/business_unit.md
+++ b/docs/resources/business_unit.md
@@ -60,7 +60,7 @@ resource "orcasecurity_business_unit" "BU-OrcaTags" {
 
 - `application` (String) Application or product line the business unit represents.
 - `business_criticality` (String) Business criticality. Valid values: `low`, `medium`, `high`, `critical`.
-- `contact_emails` (List of String) Contact emails associated with the business unit.
+- `contact_emails` (List of String) Contact emails associated with the business unit. Up to 2 values.
 - `deployment_stages` (List of String) Deployment stages associated with the business unit. Up to 2 values.
 - `filter_data` (Attributes) The filter to select the resources of the business unit. If you are creating a BU that only includes Shift Left resources (projects), this can be safely excluded. (see [below for nested schema](#nestedatt--filter_data))
 - `global_filter` (Boolean) Whether or not this is a business unit all users within your Orca org can use. If set to true, then it is accessible to all other users in your org.

--- a/docs/resources/discovery_view.md
+++ b/docs/resources/discovery_view.md
@@ -159,7 +159,7 @@ resource "orcasecurity_discovery_view" "tf_disco_view_inventory_by_account" {
 - `extra_params` (Map of String) Reserved for additional view parameters. To control which columns are displayed, use the `columns` attribute instead.
 - `filter_data` (Attributes) (see [below for nested schema](#nestedatt--filter_data))
 - `name` (String) Discovery view name.
-- `organization_level` (Boolean) If set to true, it is is a shared discovery view (can be viewed by any member of your Orca org). If set to false, it is a personal discovery view (can be viewed only by you, not other members of your Orca org).
+- `organization_level` (Boolean) If set to true, it is a shared discovery view (visible to every member of your Orca org). If set to false, it is a personal discovery view that is **scoped to the user identity behind the API token used by this provider**, not whichever user is logged into the Orca UI. Personal views created via Terraform therefore only appear in the UI when you log in as that token user; if your TF token user differs from your UI user, the view will exist in the API (`GET /api/user_preferences?view_type=discovery` returns it under `data.user_preferences[]`) but it will not be shown in the UI. For views that should be visible to multiple users, set `organization_level = true`.
 - `view_type` (String) Should be set to 'discovery' for discovery views.
 
 ### Optional

--- a/orcasecurity/api_client/business_unit.go
+++ b/orcasecurity/api_client/business_unit.go
@@ -26,6 +26,7 @@ type BusinessUnit struct {
 	Name                string                       `json:"name"`
 	Filter              *BusinessUnitFilter          `json:"filter_data,omitempty"`
 	ShiftLeftFilter     *BusinessUnitShiftLeftFilter `json:"shiftleft_filter_data,omitempty"`
+	GlobalFilter        *bool                        `json:"global_filter,omitempty"`
 	BusinessCriticality string                       `json:"business_criticality,omitempty"`
 	OwnerTeam           string                       `json:"owner_team,omitempty"`
 	Application         string                       `json:"application,omitempty"`

--- a/orcasecurity/api_client/business_unit.go
+++ b/orcasecurity/api_client/business_unit.go
@@ -22,10 +22,15 @@ type BusinessUnitShiftLeftFilter struct {
 }
 
 type BusinessUnit struct {
-	ID              string                       `json:"filter_id,omitempty"`
-	Name            string                       `json:"name"`
-	Filter          *BusinessUnitFilter          `json:"filter_data,omitempty"`
-	ShiftLeftFilter *BusinessUnitShiftLeftFilter `json:"shiftleft_filter_data,omitempty"`
+	ID                  string                       `json:"filter_id,omitempty"`
+	Name                string                       `json:"name"`
+	Filter              *BusinessUnitFilter          `json:"filter_data,omitempty"`
+	ShiftLeftFilter     *BusinessUnitShiftLeftFilter `json:"shiftleft_filter_data,omitempty"`
+	BusinessCriticality string                       `json:"business_criticality,omitempty"`
+	OwnerTeam           string                       `json:"owner_team,omitempty"`
+	Application         string                       `json:"application,omitempty"`
+	ContactEmails       []string                     `json:"contact_emails,omitempty"`
+	DeploymentStages    []string                     `json:"deployment_stages,omitempty"`
 }
 
 type businessUnitAPIResponseType struct {

--- a/orcasecurity/api_client/business_unit.go
+++ b/orcasecurity/api_client/business_unit.go
@@ -27,11 +27,11 @@ type BusinessUnit struct {
 	Filter              *BusinessUnitFilter          `json:"filter_data,omitempty"`
 	ShiftLeftFilter     *BusinessUnitShiftLeftFilter `json:"shiftleft_filter_data,omitempty"`
 	GlobalFilter        *bool                        `json:"global_filter,omitempty"`
-	BusinessCriticality string                       `json:"business_criticality,omitempty"`
-	OwnerTeam           string                       `json:"owner_team,omitempty"`
-	Application         string                       `json:"application,omitempty"`
-	ContactEmails       []string                     `json:"contact_emails,omitempty"`
-	DeploymentStages    []string                     `json:"deployment_stages,omitempty"`
+	BusinessCriticality string                       `json:"business_criticality"`
+	OwnerTeam           string                       `json:"owner_team"`
+	Application         string                       `json:"application"`
+	ContactEmails       []string                     `json:"contact_emails"`
+	DeploymentStages    []string                     `json:"deployment_stages"`
 }
 
 type businessUnitAPIResponseType struct {

--- a/orcasecurity/automation_v2/helpers_test.go
+++ b/orcasecurity/automation_v2/helpers_test.go
@@ -1,0 +1,120 @@
+package automation_v2
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-orcasecurity/orcasecurity/api_client"
+)
+
+func TestSetOptionalString_SkipNullUnknownEmpty(t *testing.T) {
+	payload := map[string]interface{}{}
+
+	setOptionalString(payload, "null", types.StringNull())
+	setOptionalString(payload, "unknown", types.StringUnknown())
+	setOptionalString(payload, "empty", types.StringValue(""))
+	setOptionalString(payload, "value", types.StringValue("hello"))
+
+	if _, ok := payload["null"]; ok {
+		t.Errorf("null value should be skipped")
+	}
+	if _, ok := payload["unknown"]; ok {
+		t.Errorf("unknown value should be skipped")
+	}
+	if _, ok := payload["empty"]; ok {
+		t.Errorf("empty string should be skipped")
+	}
+	if got := payload["value"]; got != "hello" {
+		t.Errorf("expected hello, got %v", got)
+	}
+}
+
+func TestAppendExternalConfigAction_NilTemplate(t *testing.T) {
+	out := appendExternalConfigAction(nil, nil, api_client.AutomationSlackID)
+	if len(out) != 0 {
+		t.Errorf("expected no action for nil template, got %d", len(out))
+	}
+}
+
+func TestAppendExternalConfigAction_Populated(t *testing.T) {
+	tmpl := &automationV2ExternalConfigTemplateModel{
+		ExternalConfigID: types.StringValue("cfg-123"),
+	}
+
+	out := appendExternalConfigAction(nil, tmpl, api_client.AutomationSlackID)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(out))
+	}
+	if out[0].Type != api_client.AutomationSlackID {
+		t.Errorf("expected Type %d, got %d", api_client.AutomationSlackID, out[0].Type)
+	}
+	if out[0].ExternalConfig == nil || *out[0].ExternalConfig != "cfg-123" {
+		t.Errorf("expected ExternalConfig cfg-123, got %v", out[0].ExternalConfig)
+	}
+	if len(out[0].Data) != 0 {
+		t.Errorf("expected empty Data, got %v", out[0].Data)
+	}
+}
+
+func TestAppendExternalConfigWithParentAction_OmitParentWhenNull(t *testing.T) {
+	tmpl := &automationV2ExternalConfigWithParentTemplateModel{
+		ExternalConfigID: types.StringValue("cfg-123"),
+		ParentIssueID:    types.StringNull(),
+	}
+
+	out := appendExternalConfigWithParentAction(nil, tmpl, api_client.AutomationJiraID)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(out))
+	}
+	if _, ok := out[0].Data["parent_id"]; ok {
+		t.Errorf("expected parent_id absent when null")
+	}
+}
+
+func TestAppendExternalConfigWithParentAction_IncludeParent(t *testing.T) {
+	tmpl := &automationV2ExternalConfigWithParentTemplateModel{
+		ExternalConfigID: types.StringValue("cfg-123"),
+		ParentIssueID:    types.StringValue("PROJ-1"),
+	}
+
+	out := appendExternalConfigWithParentAction(nil, tmpl, api_client.AutomationJiraID)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(out))
+	}
+	if got := out[0].Data["parent_id"]; got != "PROJ-1" {
+		t.Errorf("expected parent_id PROJ-1, got %v", got)
+	}
+}
+
+func TestAppendReasonJustificationAction_EmptyValuesSkipped(t *testing.T) {
+	out := appendReasonJustificationAction(nil, api_client.AutomationAlertDismissalID,
+		types.StringValue(""), types.StringNull(), nil)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(out))
+	}
+	if _, ok := out[0].Data["reason"]; ok {
+		t.Errorf("expected reason absent when empty")
+	}
+	if _, ok := out[0].Data["justification"]; ok {
+		t.Errorf("expected justification absent when null")
+	}
+}
+
+func TestAppendReasonJustificationAction_PopulatedWithExtra(t *testing.T) {
+	extra := map[string]interface{}{"days": int64(7)}
+	out := appendReasonJustificationAction(nil, api_client.AutomationSnoozeID,
+		types.StringValue("vacation"), types.StringValue("annual leave"), extra)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(out))
+	}
+	want := map[string]interface{}{
+		"days":          int64(7),
+		"reason":        "vacation",
+		"justification": "annual leave",
+	}
+	if !reflect.DeepEqual(out[0].Data, want) {
+		t.Errorf("expected %v, got %v", want, out[0].Data)
+	}
+}

--- a/orcasecurity/automation_v2/resource.go
+++ b/orcasecurity/automation_v2/resource.go
@@ -318,11 +318,11 @@ func (r *automationV2Resource) Schema(_ context.Context, req resource.SchemaRequ
 				Attributes: map[string]schema.Attribute{
 					"reason": schema.StringAttribute{
 						Optional:    true,
-						Description: "The reason these alerts are being dismissed.",
+						Description: "The reason these alerts are being dismissed. Optional; empty string is treated as omitted.",
 					},
 					"justification": schema.StringAttribute{
 						Optional:    true,
-						Description: "More detailed reasoning as to why these alerts are being dismissed.",
+						Description: "More detailed reasoning as to why these alerts are being dismissed. Optional; empty string is treated as omitted.",
 					},
 				},
 			},
@@ -332,11 +332,11 @@ func (r *automationV2Resource) Schema(_ context.Context, req resource.SchemaRequ
 				Attributes: map[string]schema.Attribute{
 					"reason": schema.StringAttribute{
 						Optional:    true,
-						Description: "The reason these alerts are having their score decreased.",
+						Description: "The reason these alerts are having their score decreased. Optional; empty string is treated as omitted.",
 					},
 					"justification": schema.StringAttribute{
 						Optional:    true,
-						Description: "More detailed reasoning as to why these alerts are having their score changed.",
+						Description: "More detailed reasoning as to why these alerts are having their score changed. Optional; empty string is treated as omitted.",
 					},
 				},
 			},
@@ -346,11 +346,11 @@ func (r *automationV2Resource) Schema(_ context.Context, req resource.SchemaRequ
 				Attributes: map[string]schema.Attribute{
 					"reason": schema.StringAttribute{
 						Optional:    true,
-						Description: "The reason these alerts are having their score increased.",
+						Description: "The reason these alerts are having their score increased. Optional; empty string is treated as omitted.",
 					},
 					"justification": schema.StringAttribute{
 						Optional:    true,
-						Description: "More detailed reasoning as to why these alerts are having their score changed.",
+						Description: "More detailed reasoning as to why these alerts are having their score changed. Optional; empty string is treated as omitted.",
 					},
 				},
 			},
@@ -364,11 +364,11 @@ func (r *automationV2Resource) Schema(_ context.Context, req resource.SchemaRequ
 					},
 					"reason": schema.StringAttribute{
 						Optional:    true,
-						Description: "The reason these alerts are having their score changed.",
+						Description: "The reason these alerts are having their score changed. Optional; empty string is treated as omitted.",
 					},
 					"justification": schema.StringAttribute{
 						Optional:    true,
-						Description: "More detailed reasoning as to why these alerts are having their score changed.",
+						Description: "More detailed reasoning as to why these alerts are having their score changed. Optional; empty string is treated as omitted.",
 					},
 				},
 			},
@@ -385,11 +385,11 @@ func (r *automationV2Resource) Schema(_ context.Context, req resource.SchemaRequ
 					},
 					"reason": schema.StringAttribute{
 						Optional:    true,
-						Description: "Reason for snoozing.",
+						Description: "Reason for snoozing. Optional; empty string is treated as omitted.",
 					},
 					"justification": schema.StringAttribute{
 						Optional:    true,
-						Description: "Justification for snoozing.",
+						Description: "Justification for snoozing. Optional; empty string is treated as omitted.",
 					},
 				},
 			},
@@ -463,18 +463,23 @@ func buildV2Filter(plan *automationV2FilterModel) (api_client.AutomationV2Filter
 	}, nil
 }
 
+func setOptionalString(payload map[string]interface{}, key string, value types.String) {
+	if value.IsNull() || value.IsUnknown() {
+		return
+	}
+	if v := value.ValueString(); v != "" {
+		payload[key] = v
+	}
+}
+
 func generateV2Actions(plan *automationV2ResourceModel, apiClient *api_client.APIClient) ([]api_client.AutomationV2Action, error) {
 	var actions []api_client.AutomationV2Action
 
 	if plan.SnoozeTemplate != nil {
 		payload := make(map[string]interface{})
 		payload["days"] = plan.SnoozeTemplate.Days.ValueInt64()
-		if !plan.SnoozeTemplate.Reason.IsNull() && !plan.SnoozeTemplate.Reason.IsUnknown() {
-			payload["reason"] = plan.SnoozeTemplate.Reason.ValueString()
-		}
-		if !plan.SnoozeTemplate.Justification.IsNull() && !plan.SnoozeTemplate.Justification.IsUnknown() {
-			payload["justification"] = plan.SnoozeTemplate.Justification.ValueString()
-		}
+		setOptionalString(payload, "reason", plan.SnoozeTemplate.Reason)
+		setOptionalString(payload, "justification", plan.SnoozeTemplate.Justification)
 		actions = append(actions, api_client.AutomationV2Action{
 			Type: api_client.AutomationSnoozeID,
 			Data: payload,
@@ -483,12 +488,8 @@ func generateV2Actions(plan *automationV2ResourceModel, apiClient *api_client.AP
 
 	if plan.AlertDismissalTemplate != nil {
 		payload := make(map[string]interface{})
-		if !plan.AlertDismissalTemplate.Reason.IsNull() && !plan.AlertDismissalTemplate.Reason.IsUnknown() {
-			payload["reason"] = plan.AlertDismissalTemplate.Reason.ValueString()
-		}
-		if !plan.AlertDismissalTemplate.Justification.IsNull() && !plan.AlertDismissalTemplate.Justification.IsUnknown() {
-			payload["justification"] = plan.AlertDismissalTemplate.Justification.ValueString()
-		}
+		setOptionalString(payload, "reason", plan.AlertDismissalTemplate.Reason)
+		setOptionalString(payload, "justification", plan.AlertDismissalTemplate.Justification)
 		actions = append(actions, api_client.AutomationV2Action{
 			Type: api_client.AutomationAlertDismissalID,
 			Data: payload,
@@ -498,12 +499,8 @@ func generateV2Actions(plan *automationV2ResourceModel, apiClient *api_client.AP
 	if plan.AlertScoreDecreaseTemplate != nil {
 		payload := make(map[string]interface{})
 		payload["decrease_orca_score"] = 1
-		if !plan.AlertScoreDecreaseTemplate.Reason.IsNull() && !plan.AlertScoreDecreaseTemplate.Reason.IsUnknown() {
-			payload["reason"] = plan.AlertScoreDecreaseTemplate.Reason.ValueString()
-		}
-		if !plan.AlertScoreDecreaseTemplate.Justification.IsNull() && !plan.AlertScoreDecreaseTemplate.Justification.IsUnknown() {
-			payload["justification"] = plan.AlertScoreDecreaseTemplate.Justification.ValueString()
-		}
+		setOptionalString(payload, "reason", plan.AlertScoreDecreaseTemplate.Reason)
+		setOptionalString(payload, "justification", plan.AlertScoreDecreaseTemplate.Justification)
 		actions = append(actions, api_client.AutomationV2Action{
 			Type: api_client.AutomationAlertScoreChangeID,
 			Data: payload,
@@ -513,12 +510,8 @@ func generateV2Actions(plan *automationV2ResourceModel, apiClient *api_client.AP
 	if plan.AlertScoreIncreaseTemplate != nil {
 		payload := make(map[string]interface{})
 		payload["increase_orca_score"] = 1
-		if !plan.AlertScoreIncreaseTemplate.Reason.IsNull() && !plan.AlertScoreIncreaseTemplate.Reason.IsUnknown() {
-			payload["reason"] = plan.AlertScoreIncreaseTemplate.Reason.ValueString()
-		}
-		if !plan.AlertScoreIncreaseTemplate.Justification.IsNull() && !plan.AlertScoreIncreaseTemplate.Justification.IsUnknown() {
-			payload["justification"] = plan.AlertScoreIncreaseTemplate.Justification.ValueString()
-		}
+		setOptionalString(payload, "reason", plan.AlertScoreIncreaseTemplate.Reason)
+		setOptionalString(payload, "justification", plan.AlertScoreIncreaseTemplate.Justification)
 		actions = append(actions, api_client.AutomationV2Action{
 			Type: api_client.AutomationAlertScoreChangeID,
 			Data: payload,
@@ -528,12 +521,8 @@ func generateV2Actions(plan *automationV2ResourceModel, apiClient *api_client.AP
 	if plan.AlertScoreSpecifyTemplate != nil {
 		payload := make(map[string]interface{})
 		payload["change_orca_score"] = plan.AlertScoreSpecifyTemplate.NewScore.ValueFloat64()
-		if !plan.AlertScoreSpecifyTemplate.Reason.IsNull() && !plan.AlertScoreSpecifyTemplate.Reason.IsUnknown() {
-			payload["reason"] = plan.AlertScoreSpecifyTemplate.Reason.ValueString()
-		}
-		if !plan.AlertScoreSpecifyTemplate.Justification.IsNull() && !plan.AlertScoreSpecifyTemplate.Justification.IsUnknown() {
-			payload["justification"] = plan.AlertScoreSpecifyTemplate.Justification.ValueString()
-		}
+		setOptionalString(payload, "reason", plan.AlertScoreSpecifyTemplate.Reason)
+		setOptionalString(payload, "justification", plan.AlertScoreSpecifyTemplate.Justification)
 		actions = append(actions, api_client.AutomationV2Action{
 			Type: api_client.AutomationAlertScoreChangeID,
 			Data: payload,

--- a/orcasecurity/automation_v2/resource.go
+++ b/orcasecurity/automation_v2/resource.go
@@ -28,6 +28,8 @@ var (
 	_ resource.ResourceWithConfigValidators = &automationV2Resource{}
 )
 
+const scoreChangeJustificationDescription = "More detailed reasoning as to why these alerts are having their score changed. Optional; empty string is treated as omitted."
+
 type automationV2Resource struct {
 	apiClient *api_client.APIClient
 }
@@ -336,7 +338,7 @@ func (r *automationV2Resource) Schema(_ context.Context, req resource.SchemaRequ
 					},
 					"justification": schema.StringAttribute{
 						Optional:    true,
-						Description: "More detailed reasoning as to why these alerts are having their score changed. Optional; empty string is treated as omitted.",
+						Description: scoreChangeJustificationDescription,
 					},
 				},
 			},
@@ -350,7 +352,7 @@ func (r *automationV2Resource) Schema(_ context.Context, req resource.SchemaRequ
 					},
 					"justification": schema.StringAttribute{
 						Optional:    true,
-						Description: "More detailed reasoning as to why these alerts are having their score changed. Optional; empty string is treated as omitted.",
+						Description: scoreChangeJustificationDescription,
 					},
 				},
 			},
@@ -368,7 +370,7 @@ func (r *automationV2Resource) Schema(_ context.Context, req resource.SchemaRequ
 					},
 					"justification": schema.StringAttribute{
 						Optional:    true,
-						Description: "More detailed reasoning as to why these alerts are having their score changed. Optional; empty string is treated as omitted.",
+						Description: scoreChangeJustificationDescription,
 					},
 				},
 			},

--- a/orcasecurity/automation_v2/resource.go
+++ b/orcasecurity/automation_v2/resource.go
@@ -472,332 +472,130 @@ func setOptionalString(payload map[string]interface{}, key string, value types.S
 	}
 }
 
+func appendExternalConfigAction(actions []api_client.AutomationV2Action, tmpl *automationV2ExternalConfigTemplateModel, actionType int32) []api_client.AutomationV2Action {
+	if tmpl == nil {
+		return actions
+	}
+	externalConfigID := tmpl.ExternalConfigID.ValueString()
+	return append(actions, api_client.AutomationV2Action{
+		Type:           actionType,
+		Data:           map[string]interface{}{},
+		ExternalConfig: &externalConfigID,
+	})
+}
+
+func appendExternalConfigWithParentAction(actions []api_client.AutomationV2Action, tmpl *automationV2ExternalConfigWithParentTemplateModel, actionType int32) []api_client.AutomationV2Action {
+	if tmpl == nil || tmpl.ExternalConfigID.IsNull() {
+		return actions
+	}
+	externalConfigID := tmpl.ExternalConfigID.ValueString()
+	payload := map[string]interface{}{}
+	if !tmpl.ParentIssueID.IsNull() {
+		payload["parent_id"] = tmpl.ParentIssueID.ValueString()
+	}
+	return append(actions, api_client.AutomationV2Action{
+		Type:           actionType,
+		Data:           payload,
+		ExternalConfig: &externalConfigID,
+	})
+}
+
+func appendReasonJustificationAction(actions []api_client.AutomationV2Action, actionType int32, reason, justification types.String, extra map[string]interface{}) []api_client.AutomationV2Action {
+	payload := extra
+	if payload == nil {
+		payload = map[string]interface{}{}
+	}
+	setOptionalString(payload, "reason", reason)
+	setOptionalString(payload, "justification", justification)
+	return append(actions, api_client.AutomationV2Action{
+		Type: actionType,
+		Data: payload,
+	})
+}
+
 func generateV2Actions(plan *automationV2ResourceModel, apiClient *api_client.APIClient) ([]api_client.AutomationV2Action, error) {
 	var actions []api_client.AutomationV2Action
 
 	if plan.SnoozeTemplate != nil {
-		payload := make(map[string]interface{})
-		payload["days"] = plan.SnoozeTemplate.Days.ValueInt64()
-		setOptionalString(payload, "reason", plan.SnoozeTemplate.Reason)
-		setOptionalString(payload, "justification", plan.SnoozeTemplate.Justification)
-		actions = append(actions, api_client.AutomationV2Action{
-			Type: api_client.AutomationSnoozeID,
-			Data: payload,
-		})
+		actions = appendReasonJustificationAction(actions, api_client.AutomationSnoozeID,
+			plan.SnoozeTemplate.Reason, plan.SnoozeTemplate.Justification,
+			map[string]interface{}{"days": plan.SnoozeTemplate.Days.ValueInt64()})
 	}
 
 	if plan.AlertDismissalTemplate != nil {
-		payload := make(map[string]interface{})
-		setOptionalString(payload, "reason", plan.AlertDismissalTemplate.Reason)
-		setOptionalString(payload, "justification", plan.AlertDismissalTemplate.Justification)
-		actions = append(actions, api_client.AutomationV2Action{
-			Type: api_client.AutomationAlertDismissalID,
-			Data: payload,
-		})
+		actions = appendReasonJustificationAction(actions, api_client.AutomationAlertDismissalID,
+			plan.AlertDismissalTemplate.Reason, plan.AlertDismissalTemplate.Justification, nil)
 	}
 
 	if plan.AlertScoreDecreaseTemplate != nil {
-		payload := make(map[string]interface{})
-		payload["decrease_orca_score"] = 1
-		setOptionalString(payload, "reason", plan.AlertScoreDecreaseTemplate.Reason)
-		setOptionalString(payload, "justification", plan.AlertScoreDecreaseTemplate.Justification)
-		actions = append(actions, api_client.AutomationV2Action{
-			Type: api_client.AutomationAlertScoreChangeID,
-			Data: payload,
-		})
+		actions = appendReasonJustificationAction(actions, api_client.AutomationAlertScoreChangeID,
+			plan.AlertScoreDecreaseTemplate.Reason, plan.AlertScoreDecreaseTemplate.Justification,
+			map[string]interface{}{"decrease_orca_score": 1})
 	}
 
 	if plan.AlertScoreIncreaseTemplate != nil {
-		payload := make(map[string]interface{})
-		payload["increase_orca_score"] = 1
-		setOptionalString(payload, "reason", plan.AlertScoreIncreaseTemplate.Reason)
-		setOptionalString(payload, "justification", plan.AlertScoreIncreaseTemplate.Justification)
-		actions = append(actions, api_client.AutomationV2Action{
-			Type: api_client.AutomationAlertScoreChangeID,
-			Data: payload,
-		})
+		actions = appendReasonJustificationAction(actions, api_client.AutomationAlertScoreChangeID,
+			plan.AlertScoreIncreaseTemplate.Reason, plan.AlertScoreIncreaseTemplate.Justification,
+			map[string]interface{}{"increase_orca_score": 1})
 	}
 
 	if plan.AlertScoreSpecifyTemplate != nil {
-		payload := make(map[string]interface{})
-		payload["change_orca_score"] = plan.AlertScoreSpecifyTemplate.NewScore.ValueFloat64()
-		setOptionalString(payload, "reason", plan.AlertScoreSpecifyTemplate.Reason)
-		setOptionalString(payload, "justification", plan.AlertScoreSpecifyTemplate.Justification)
-		actions = append(actions, api_client.AutomationV2Action{
-			Type: api_client.AutomationAlertScoreChangeID,
-			Data: payload,
-		})
+		actions = appendReasonJustificationAction(actions, api_client.AutomationAlertScoreChangeID,
+			plan.AlertScoreSpecifyTemplate.Reason, plan.AlertScoreSpecifyTemplate.Justification,
+			map[string]interface{}{"change_orca_score": plan.AlertScoreSpecifyTemplate.NewScore.ValueFloat64()})
 	}
 
-	if plan.AwsSecurityHubTemplate != nil {
-		externalConfigID := plan.AwsSecurityHubTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationAWSSecurityHubID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
+	externalConfigBindings := []struct {
+		tmpl       *automationV2ExternalConfigTemplateModel
+		actionType int32
+	}{
+		{plan.AwsSecurityHubTemplate, api_client.AutomationAWSSecurityHubID},
+		{plan.AwsSecurityLakeTemplate, api_client.AutomationAwsSecurityLakeID},
+		{plan.AwsSqsTemplate, api_client.AutomationAwsSqsID},
+		{plan.AwsSnsTemplate, api_client.AutomationAwsSnsID},
+		{plan.AzureSentinelTemplate, api_client.AutomationAzureSentinelID},
+		{plan.ChronicleTemplate, api_client.AutomationChronicleID},
+		{plan.CoralogixTemplate, api_client.AutomationCoralogixID},
+		{plan.CriblTemplate, api_client.AutomationCriblID},
+		{plan.GcpPubSubTemplate, api_client.AutomationGcpPubSubID},
+		{plan.LinearTemplate, api_client.AutomationLinearID},
+		{plan.MondayTemplate, api_client.AutomationMondayID},
+		{plan.MsTeamsTemplate, api_client.AutomationMsTeamsID},
+		{plan.OpsgenieTemplate, api_client.AutomationOpsgenieID},
+		{plan.OpusTemplate, api_client.AutomationOpusID},
+		{plan.PagerDutyTemplate, api_client.AutomationPagerDutyID},
+		{plan.PantherTemplate, api_client.AutomationPantherID},
+		{plan.ServiceNowIncidentsTemplate, api_client.AutomationServiceNowIncidentsID},
+		{plan.ServiceNowSIIncidentsTemplate, api_client.AutomationServiceNowSIIncidentsID},
+		{plan.SlackTemplate, api_client.AutomationSlackID},
+		{plan.SnowflakeTemplate, api_client.AutomationSnowflakeID},
+		{plan.SplunkTemplate, api_client.AutomationSplunkID},
+		{plan.SumoLogicTemplate, api_client.AutomationSumoLogicID},
+		{plan.TinesTemplate, api_client.AutomationTinesID},
+		{plan.TorqTemplate, api_client.AutomationTorqID},
+		{plan.WebhookTemplate, api_client.AutomationWebhookID},
+	}
+	for _, b := range externalConfigBindings {
+		actions = appendExternalConfigAction(actions, b.tmpl, b.actionType)
 	}
 
-	if plan.AwsSecurityLakeTemplate != nil {
-		externalConfigID := plan.AwsSecurityLakeTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationAwsSecurityLakeID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
+	externalConfigWithParentBindings := []struct {
+		tmpl       *automationV2ExternalConfigWithParentTemplateModel
+		actionType int32
+	}{
+		{plan.AzureDevopsTemplate, api_client.AutomationAzureDevopsID},
+		{plan.JiraCloudTemplate, api_client.AutomationJiraID},
+		{plan.JiraServerTemplate, api_client.AutomationJiraServerID},
 	}
-
-	if plan.AwsSqsTemplate != nil {
-		externalConfigID := plan.AwsSqsTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationAwsSqsID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.AzureDevopsTemplate != nil && !plan.AzureDevopsTemplate.ExternalConfigID.IsNull() {
-		externalConfigID := plan.AzureDevopsTemplate.ExternalConfigID.ValueString()
-
-		payload := make(map[string]interface{})
-		if !plan.AzureDevopsTemplate.ParentIssueID.IsNull() {
-			payload["parent_id"] = plan.AzureDevopsTemplate.ParentIssueID.ValueString()
-		}
-
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationAzureDevopsID,
-			Data:           payload,
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.AzureSentinelTemplate != nil {
-		externalConfigID := plan.AzureSentinelTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationAzureSentinelID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.CoralogixTemplate != nil {
-		externalConfigID := plan.CoralogixTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationCoralogixID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.GcpPubSubTemplate != nil {
-		externalConfigID := plan.GcpPubSubTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationGcpPubSubID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.JiraCloudTemplate != nil && !plan.JiraCloudTemplate.ExternalConfigID.IsNull() {
-		externalConfigID := plan.JiraCloudTemplate.ExternalConfigID.ValueString()
-
-		payload := make(map[string]interface{})
-		if !plan.JiraCloudTemplate.ParentIssueID.IsNull() {
-			payload["parent_id"] = plan.JiraCloudTemplate.ParentIssueID.ValueString()
-		}
-
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationJiraID,
-			Data:           payload,
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.JiraServerTemplate != nil && !plan.JiraServerTemplate.ExternalConfigID.IsNull() {
-		externalConfigID := plan.JiraServerTemplate.ExternalConfigID.ValueString()
-
-		payload := make(map[string]interface{})
-		if !plan.JiraServerTemplate.ParentIssueID.IsNull() {
-			payload["parent_id"] = plan.JiraServerTemplate.ParentIssueID.ValueString()
-		}
-
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationJiraServerID,
-			Data:           payload,
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.OpsgenieTemplate != nil {
-		externalConfigID := plan.OpsgenieTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationOpsgenieID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.PagerDutyTemplate != nil {
-		externalConfigID := plan.PagerDutyTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationPagerDutyID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.SnowflakeTemplate != nil {
-		externalConfigID := plan.SnowflakeTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationSnowflakeID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.SplunkTemplate != nil {
-		externalConfigID := plan.SplunkTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationSplunkID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.SumoLogicTemplate != nil {
-		externalConfigID := plan.SumoLogicTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationSumoLogicID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.TinesTemplate != nil {
-		externalConfigID := plan.TinesTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationTinesID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.TorqTemplate != nil {
-		externalConfigID := plan.TorqTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationTorqID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.WebhookTemplate != nil {
-		externalConfigID := plan.WebhookTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationWebhookID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.MsTeamsTemplate != nil {
-		externalConfigID := plan.MsTeamsTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationMsTeamsID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.ChronicleTemplate != nil {
-		externalConfigID := plan.ChronicleTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationChronicleID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.PantherTemplate != nil {
-		externalConfigID := plan.PantherTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationPantherID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.ServiceNowIncidentsTemplate != nil {
-		externalConfigID := plan.ServiceNowIncidentsTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationServiceNowIncidentsID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.ServiceNowSIIncidentsTemplate != nil {
-		externalConfigID := plan.ServiceNowSIIncidentsTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationServiceNowSIIncidentsID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.MondayTemplate != nil {
-		externalConfigID := plan.MondayTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationMondayID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.LinearTemplate != nil {
-		externalConfigID := plan.LinearTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationLinearID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.AwsSnsTemplate != nil {
-		externalConfigID := plan.AwsSnsTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationAwsSnsID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
+	for _, b := range externalConfigWithParentBindings {
+		actions = appendExternalConfigWithParentAction(actions, b.tmpl, b.actionType)
 	}
 
 	if plan.DatadogTemplate != nil {
 		externalConfigID := plan.DatadogTemplate.ExternalConfigID.ValueString()
-		payload := make(map[string]interface{})
-		payload["type"] = plan.DatadogTemplate.Type.ValueString()
-
 		actions = append(actions, api_client.AutomationV2Action{
 			Type:           api_client.AutomationDatadogID,
-			Data:           payload,
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.CriblTemplate != nil {
-		externalConfigID := plan.CriblTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationCriblID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
-		})
-	}
-
-	if plan.OpusTemplate != nil {
-		externalConfigID := plan.OpusTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationOpusID,
-			Data:           make(map[string]interface{}),
+			Data:           map[string]interface{}{"type": plan.DatadogTemplate.Type.ValueString()},
 			ExternalConfig: &externalConfigID,
 		})
 	}
@@ -805,23 +603,12 @@ func generateV2Actions(plan *automationV2ResourceModel, apiClient *api_client.AP
 	if plan.EmailTemplate != nil {
 		var emailAddresses []string
 		_ = plan.EmailTemplate.EmailAddresses.ElementsAs(context.Background(), &emailAddresses, false)
-
-		payload := make(map[string]interface{})
-		payload["email"] = emailAddresses
-		payload["multi_alerts"] = plan.EmailTemplate.MultiAlerts.ValueBool()
-
 		actions = append(actions, api_client.AutomationV2Action{
 			Type: api_client.AutomationEmailID,
-			Data: payload,
-		})
-	}
-
-	if plan.SlackTemplate != nil {
-		externalConfigID := plan.SlackTemplate.ExternalConfigID.ValueString()
-		actions = append(actions, api_client.AutomationV2Action{
-			Type:           api_client.AutomationSlackID,
-			Data:           make(map[string]interface{}),
-			ExternalConfig: &externalConfigID,
+			Data: map[string]interface{}{
+				"email":        emailAddresses,
+				"multi_alerts": plan.EmailTemplate.MultiAlerts.ValueBool(),
+			},
 		})
 	}
 

--- a/orcasecurity/business_unit/metadata_test.go
+++ b/orcasecurity/business_unit/metadata_test.go
@@ -1,0 +1,175 @@
+package business_unit
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-orcasecurity/orcasecurity/api_client"
+)
+
+func TestApplyMetadataToRequest_Populated(t *testing.T) {
+	globalFilter := true
+	plan := &businessUnitResourceModel{
+		GlobalFilter:        types.BoolValue(globalFilter),
+		BusinessCriticality: types.StringValue("high"),
+		OwnerTeam:           types.StringValue("platform"),
+		Application:         types.StringValue("billing"),
+		ContactEmails:       []types.String{types.StringValue("a@x.com"), types.StringValue("b@x.com")},
+		DeploymentStages:    []types.String{types.StringValue("dev"), types.StringValue("prod")},
+	}
+
+	req := api_client.BusinessUnit{Name: "test"}
+	applyMetadataToRequest(&req, plan)
+
+	if req.GlobalFilter == nil || *req.GlobalFilter != true {
+		t.Errorf("expected GlobalFilter true, got %v", req.GlobalFilter)
+	}
+	if req.BusinessCriticality != "high" {
+		t.Errorf("expected high, got %q", req.BusinessCriticality)
+	}
+	if req.OwnerTeam != "platform" {
+		t.Errorf("expected platform, got %q", req.OwnerTeam)
+	}
+	if req.Application != "billing" {
+		t.Errorf("expected billing, got %q", req.Application)
+	}
+	if !reflect.DeepEqual(req.ContactEmails, []string{"a@x.com", "b@x.com"}) {
+		t.Errorf("contact emails mismatch: %v", req.ContactEmails)
+	}
+	if !reflect.DeepEqual(req.DeploymentStages, []string{"dev", "prod"}) {
+		t.Errorf("deployment stages mismatch: %v", req.DeploymentStages)
+	}
+}
+
+func TestApplyMetadataToRequest_NullPlanProducesEmptyValues(t *testing.T) {
+	plan := &businessUnitResourceModel{
+		GlobalFilter:        types.BoolNull(),
+		BusinessCriticality: types.StringNull(),
+		OwnerTeam:           types.StringNull(),
+		Application:         types.StringNull(),
+		ContactEmails:       nil,
+		DeploymentStages:    nil,
+	}
+
+	req := api_client.BusinessUnit{Name: "test"}
+	applyMetadataToRequest(&req, plan)
+
+	if req.GlobalFilter != nil {
+		t.Errorf("expected nil GlobalFilter, got %v", req.GlobalFilter)
+	}
+	if req.BusinessCriticality != "" {
+		t.Errorf("expected empty BusinessCriticality, got %q", req.BusinessCriticality)
+	}
+	if req.OwnerTeam != "" {
+		t.Errorf("expected empty OwnerTeam, got %q", req.OwnerTeam)
+	}
+	if req.Application != "" {
+		t.Errorf("expected empty Application, got %q", req.Application)
+	}
+	if len(req.ContactEmails) != 0 {
+		t.Errorf("expected empty ContactEmails, got %v", req.ContactEmails)
+	}
+	if len(req.DeploymentStages) != 0 {
+		t.Errorf("expected empty DeploymentStages, got %v", req.DeploymentStages)
+	}
+}
+
+func TestBusinessUnit_NullPlanSerializesEmptyMetadata(t *testing.T) {
+	plan := &businessUnitResourceModel{
+		Name:                types.StringValue("test"),
+		GlobalFilter:        types.BoolNull(),
+		BusinessCriticality: types.StringNull(),
+		OwnerTeam:           types.StringNull(),
+		Application:         types.StringNull(),
+		ContactEmails:       nil,
+		DeploymentStages:    nil,
+	}
+
+	req := api_client.BusinessUnit{Name: plan.Name.ValueString()}
+	applyMetadataToRequest(&req, plan)
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+
+	for _, want := range []string{
+		`"business_criticality":""`,
+		`"owner_team":""`,
+		`"application":""`,
+		`"contact_emails":[]`,
+		`"deployment_stages":[]`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected JSON to contain %s, got %s", want, got)
+		}
+	}
+	if strings.Contains(got, `"global_filter"`) {
+		t.Errorf("expected global_filter omitted when null, got %s", got)
+	}
+}
+
+func TestSetMetadataInState_EmptyAPIValuesYieldNull(t *testing.T) {
+	state := &businessUnitResourceModel{}
+	instance := &api_client.BusinessUnit{}
+
+	setMetadataInState(state, instance)
+
+	if !state.GlobalFilter.IsNull() {
+		t.Errorf("expected GlobalFilter null, got %v", state.GlobalFilter)
+	}
+	if !state.BusinessCriticality.IsNull() {
+		t.Errorf("expected BusinessCriticality null, got %v", state.BusinessCriticality)
+	}
+	if !state.OwnerTeam.IsNull() {
+		t.Errorf("expected OwnerTeam null, got %v", state.OwnerTeam)
+	}
+	if !state.Application.IsNull() {
+		t.Errorf("expected Application null, got %v", state.Application)
+	}
+	if state.ContactEmails != nil {
+		t.Errorf("expected ContactEmails nil, got %v", state.ContactEmails)
+	}
+	if state.DeploymentStages != nil {
+		t.Errorf("expected DeploymentStages nil, got %v", state.DeploymentStages)
+	}
+}
+
+func TestSetMetadataInState_PopulatedAPIValues(t *testing.T) {
+	gf := true
+	state := &businessUnitResourceModel{}
+	instance := &api_client.BusinessUnit{
+		GlobalFilter:        &gf,
+		BusinessCriticality: "critical",
+		OwnerTeam:           "sec",
+		Application:         "infra",
+		ContactEmails:       []string{"alert@x.com"},
+		DeploymentStages:    []string{"staging"},
+	}
+
+	setMetadataInState(state, instance)
+
+	if !state.GlobalFilter.Equal(types.BoolValue(true)) {
+		t.Errorf("expected GlobalFilter true, got %v", state.GlobalFilter)
+	}
+	if state.BusinessCriticality.ValueString() != "critical" {
+		t.Errorf("expected critical, got %s", state.BusinessCriticality.ValueString())
+	}
+	if state.OwnerTeam.ValueString() != "sec" {
+		t.Errorf("expected sec, got %s", state.OwnerTeam.ValueString())
+	}
+	if state.Application.ValueString() != "infra" {
+		t.Errorf("expected infra, got %s", state.Application.ValueString())
+	}
+	if len(state.ContactEmails) != 1 || state.ContactEmails[0].ValueString() != "alert@x.com" {
+		t.Errorf("contact emails mismatch: %v", state.ContactEmails)
+	}
+	if len(state.DeploymentStages) != 1 || state.DeploymentStages[0].ValueString() != "staging" {
+		t.Errorf("deployment stages mismatch: %v", state.DeploymentStages)
+	}
+}

--- a/orcasecurity/business_unit/resource.go
+++ b/orcasecurity/business_unit/resource.go
@@ -44,11 +44,16 @@ type businessUnitShiftLeftFilterModel struct {
 }
 
 type businessUnitResourceModel struct {
-	ID              types.String                      `tfsdk:"id"`
-	Name            types.String                      `tfsdk:"name"`
-	Filter          *businessUnitFilterModel          `tfsdk:"filter_data"`
-	ShiftLeftFilter *businessUnitShiftLeftFilterModel `tfsdk:"shiftleft_filter_data"`
-	GlobalFilter    types.Bool                        `tfsdk:"global_filter"`
+	ID                  types.String                      `tfsdk:"id"`
+	Name                types.String                      `tfsdk:"name"`
+	Filter              *businessUnitFilterModel          `tfsdk:"filter_data"`
+	ShiftLeftFilter     *businessUnitShiftLeftFilterModel `tfsdk:"shiftleft_filter_data"`
+	GlobalFilter        types.Bool                        `tfsdk:"global_filter"`
+	BusinessCriticality types.String                      `tfsdk:"business_criticality"`
+	OwnerTeam           types.String                      `tfsdk:"owner_team"`
+	Application         types.String                      `tfsdk:"application"`
+	ContactEmails       []types.String                    `tfsdk:"contact_emails"`
+	DeploymentStages    []types.String                    `tfsdk:"deployment_stages"`
 }
 
 // uuidValidator validates that a string is a valid UUID.
@@ -120,6 +125,7 @@ func (r *businessUnitResource) ImportState(ctx context.Context, req resource.Imp
 
 	state.ShiftLeftFilter = apiShiftLeftFilterToModel(businessUnit.ShiftLeftFilter)
 	state.Filter = apiFilterToModel(businessUnit.Filter)
+	setMetadataInState(&state, businessUnit)
 
 	// Set the entire state at once
 	diags := resp.State.Set(ctx, &state)
@@ -147,6 +153,34 @@ func (r *businessUnitResource) Schema(ctx context.Context, req resource.SchemaRe
 			"global_filter": schema.BoolAttribute{
 				Description: "Whether or not this is a business unit all users within your Orca org can use. If set to true, then it is accessible to all other users in your org.",
 				Optional:    true,
+			},
+			"business_criticality": schema.StringAttribute{
+				Description: "Business criticality. Valid values: `low`, `medium`, `high`, `critical`.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("low", "medium", "high", "critical"),
+				},
+			},
+			"owner_team": schema.StringAttribute{
+				Description: "Owning team or department for the business unit.",
+				Optional:    true,
+			},
+			"application": schema.StringAttribute{
+				Description: "Application or product line the business unit represents.",
+				Optional:    true,
+			},
+			"contact_emails": schema.ListAttribute{
+				Description: "Contact emails associated with the business unit.",
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"deployment_stages": schema.ListAttribute{
+				Description: "Deployment stages associated with the business unit. Up to 2 values.",
+				ElementType: types.StringType,
+				Optional:    true,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(2),
+				},
 			},
 			"shiftleft_filter_data": schema.SingleNestedAttribute{
 				Description: "The filter to select Shift Left resources for the business unit. If you are creating a BU that only includes Shift Left resources (projects), this can be safely excluded.",
@@ -330,6 +364,60 @@ func stringSliceToTypes(s []string) []types.String {
 	return out
 }
 
+func typesSliceToStrings(in []types.String) []string {
+	out := make([]string, len(in))
+	for i, v := range in {
+		out[i] = v.ValueString()
+	}
+	return out
+}
+
+func applyMetadataToRequest(req *api_client.BusinessUnit, plan *businessUnitResourceModel) {
+	if !plan.BusinessCriticality.IsNull() && !plan.BusinessCriticality.IsUnknown() {
+		req.BusinessCriticality = plan.BusinessCriticality.ValueString()
+	}
+	if !plan.OwnerTeam.IsNull() && !plan.OwnerTeam.IsUnknown() {
+		req.OwnerTeam = plan.OwnerTeam.ValueString()
+	}
+	if !plan.Application.IsNull() && !plan.Application.IsUnknown() {
+		req.Application = plan.Application.ValueString()
+	}
+	if len(plan.ContactEmails) > 0 {
+		req.ContactEmails = typesSliceToStrings(plan.ContactEmails)
+	}
+	if len(plan.DeploymentStages) > 0 {
+		req.DeploymentStages = typesSliceToStrings(plan.DeploymentStages)
+	}
+}
+
+func setMetadataInState(state *businessUnitResourceModel, instance *api_client.BusinessUnit) {
+	if instance.BusinessCriticality != "" {
+		state.BusinessCriticality = types.StringValue(instance.BusinessCriticality)
+	} else {
+		state.BusinessCriticality = types.StringNull()
+	}
+	if instance.OwnerTeam != "" {
+		state.OwnerTeam = types.StringValue(instance.OwnerTeam)
+	} else {
+		state.OwnerTeam = types.StringNull()
+	}
+	if instance.Application != "" {
+		state.Application = types.StringValue(instance.Application)
+	} else {
+		state.Application = types.StringNull()
+	}
+	if len(instance.ContactEmails) > 0 {
+		state.ContactEmails = stringSliceToTypes(instance.ContactEmails)
+	} else {
+		state.ContactEmails = nil
+	}
+	if len(instance.DeploymentStages) > 0 {
+		state.DeploymentStages = stringSliceToTypes(instance.DeploymentStages)
+	} else {
+		state.DeploymentStages = nil
+	}
+}
+
 func (r *businessUnitResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan businessUnitResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -380,6 +468,7 @@ func (r *businessUnitResource) Create(ctx context.Context, req resource.CreateRe
 		Filter:          businessUnitFilter,
 		ShiftLeftFilter: businessUnitShiftLeftFilter,
 	}
+	applyMetadataToRequest(&createReq, &plan)
 
 	// Make the API call to create the business unit
 	instance, err := r.apiClient.CreateBusinessUnit(createReq)
@@ -447,6 +536,7 @@ func (r *businessUnitResource) Read(ctx context.Context, req resource.ReadReques
 		state.Filter.CloudAccountIds = state.Filter.CloudAccounts
 		state.Filter.CloudAccounts = nil
 	}
+	setMetadataInState(&state, instance)
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -480,6 +570,7 @@ func (r *businessUnitResource) Update(ctx context.Context, req resource.UpdateRe
 			Name:   plan.Name.ValueString(),
 			Filter: &filter,
 		}
+		applyMetadataToRequest(&updateReq, &plan)
 
 		_, err := r.apiClient.UpdateBusinessUnit(plan.ID.ValueString(), updateReq)
 		if err != nil {
@@ -513,6 +604,7 @@ func (r *businessUnitResource) Update(ctx context.Context, req resource.UpdateRe
 			Name:            plan.Name.ValueString(),
 			ShiftLeftFilter: &slFilter,
 		}
+		applyMetadataToRequest(&updateReq, &plan)
 
 		instance, err := r.apiClient.UpdateBusinessUnit(updateReq.ID, updateReq)
 
@@ -546,6 +638,7 @@ func (r *businessUnitResource) Update(ctx context.Context, req resource.UpdateRe
 			ShiftLeftFilter: &slFilter,
 			Filter:          &filter,
 		}
+		applyMetadataToRequest(&updateReq, &plan)
 
 		instance, err := r.apiClient.UpdateBusinessUnit(updateReq.ID, updateReq)
 
@@ -573,6 +666,7 @@ func (r *businessUnitResource) Update(ctx context.Context, req resource.UpdateRe
 			Filter: &filter,
 			Name:   plan.Name.ValueString(),
 		}
+		applyMetadataToRequest(&updateReq, &plan)
 
 		_, err := r.apiClient.UpdateBusinessUnit(plan.ID.ValueString(), updateReq)
 		if err != nil {
@@ -605,6 +699,7 @@ func (r *businessUnitResource) Update(ctx context.Context, req resource.UpdateRe
 			Filter: &filter,
 			Name:   plan.Name.ValueString(),
 		}
+		applyMetadataToRequest(&updateReq, &plan)
 
 		_, err := r.apiClient.UpdateBusinessUnit(plan.ID.ValueString(), updateReq)
 		if err != nil {
@@ -637,6 +732,7 @@ func (r *businessUnitResource) Update(ctx context.Context, req resource.UpdateRe
 			Filter: &filter,
 			Name:   plan.Name.ValueString(),
 		}
+		applyMetadataToRequest(&updateReq, &plan)
 
 		_, err := r.apiClient.UpdateBusinessUnit(plan.ID.ValueString(), updateReq)
 		if err != nil {
@@ -669,6 +765,7 @@ func (r *businessUnitResource) Update(ctx context.Context, req resource.UpdateRe
 			Filter: &filter,
 			Name:   plan.Name.ValueString(),
 		}
+		applyMetadataToRequest(&updateReq, &plan)
 
 		_, err := r.apiClient.UpdateBusinessUnit(plan.ID.ValueString(), updateReq)
 		if err != nil {

--- a/orcasecurity/business_unit/resource.go
+++ b/orcasecurity/business_unit/resource.go
@@ -373,6 +373,10 @@ func typesSliceToStrings(in []types.String) []string {
 }
 
 func applyMetadataToRequest(req *api_client.BusinessUnit, plan *businessUnitResourceModel) {
+	if !plan.GlobalFilter.IsNull() && !plan.GlobalFilter.IsUnknown() {
+		v := plan.GlobalFilter.ValueBool()
+		req.GlobalFilter = &v
+	}
 	if !plan.BusinessCriticality.IsNull() && !plan.BusinessCriticality.IsUnknown() {
 		req.BusinessCriticality = plan.BusinessCriticality.ValueString()
 	}
@@ -391,6 +395,11 @@ func applyMetadataToRequest(req *api_client.BusinessUnit, plan *businessUnitReso
 }
 
 func setMetadataInState(state *businessUnitResourceModel, instance *api_client.BusinessUnit) {
+	if instance.GlobalFilter != nil {
+		state.GlobalFilter = types.BoolValue(*instance.GlobalFilter)
+	} else {
+		state.GlobalFilter = types.BoolNull()
+	}
 	if instance.BusinessCriticality != "" {
 		state.BusinessCriticality = types.StringValue(instance.BusinessCriticality)
 	} else {
@@ -781,6 +790,26 @@ func (r *businessUnitResource) Update(ctx context.Context, req resource.UpdateRe
 			resp.Diagnostics.AddError(
 				"Error reading business unit",
 				"Could not read Business Unit ID: "+plan.ID.ValueString()+": "+err.Error(),
+			)
+			return
+		}
+
+		diags = resp.State.Set(ctx, &plan)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	} else {
+		updateReq := api_client.BusinessUnit{
+			Name: plan.Name.ValueString(),
+		}
+		applyMetadataToRequest(&updateReq, &plan)
+
+		_, err := r.apiClient.UpdateBusinessUnit(plan.ID.ValueString(), updateReq)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error updating business unit",
+				"Could not update business unit, unexpected error: "+err.Error(),
 			)
 			return
 		}

--- a/orcasecurity/business_unit/resource.go
+++ b/orcasecurity/business_unit/resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -162,29 +163,49 @@ func (r *businessUnitResource) Schema(ctx context.Context, req resource.SchemaRe
 			"business_criticality": schema.StringAttribute{
 				Description: "Business criticality. Valid values: `low`, `medium`, `high`, `critical`.",
 				Optional:    true,
+				Computed:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("low", "medium", "high", "critical"),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"owner_team": schema.StringAttribute{
 				Description: "Owning team or department for the business unit.",
 				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"application": schema.StringAttribute{
 				Description: "Application or product line the business unit represents.",
 				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"contact_emails": schema.ListAttribute{
 				Description: "Contact emails associated with the business unit.",
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"deployment_stages": schema.ListAttribute{
 				Description: "Deployment stages associated with the business unit. Up to 2 values.",
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(2),
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"shiftleft_filter_data": schema.SingleNestedAttribute{

--- a/orcasecurity/business_unit/resource.go
+++ b/orcasecurity/business_unit/resource.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -163,49 +162,29 @@ func (r *businessUnitResource) Schema(ctx context.Context, req resource.SchemaRe
 			"business_criticality": schema.StringAttribute{
 				Description: "Business criticality. Valid values: `low`, `medium`, `high`, `critical`.",
 				Optional:    true,
-				Computed:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("low", "medium", "high", "critical"),
-				},
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"owner_team": schema.StringAttribute{
 				Description: "Owning team or department for the business unit.",
 				Optional:    true,
-				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"application": schema.StringAttribute{
 				Description: "Application or product line the business unit represents.",
 				Optional:    true,
-				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"contact_emails": schema.ListAttribute{
 				Description: "Contact emails associated with the business unit.",
 				ElementType: types.StringType,
 				Optional:    true,
-				Computed:    true,
-				PlanModifiers: []planmodifier.List{
-					listplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"deployment_stages": schema.ListAttribute{
 				Description: "Deployment stages associated with the business unit. Up to 2 values.",
 				ElementType: types.StringType,
 				Optional:    true,
-				Computed:    true,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(2),
-				},
-				PlanModifiers: []planmodifier.List{
-					listplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"shiftleft_filter_data": schema.SingleNestedAttribute{
@@ -403,21 +382,11 @@ func applyMetadataToRequest(req *api_client.BusinessUnit, plan *businessUnitReso
 		v := plan.GlobalFilter.ValueBool()
 		req.GlobalFilter = &v
 	}
-	if !plan.BusinessCriticality.IsNull() && !plan.BusinessCriticality.IsUnknown() {
-		req.BusinessCriticality = plan.BusinessCriticality.ValueString()
-	}
-	if !plan.OwnerTeam.IsNull() && !plan.OwnerTeam.IsUnknown() {
-		req.OwnerTeam = plan.OwnerTeam.ValueString()
-	}
-	if !plan.Application.IsNull() && !plan.Application.IsUnknown() {
-		req.Application = plan.Application.ValueString()
-	}
-	if len(plan.ContactEmails) > 0 {
-		req.ContactEmails = typesSliceToStrings(plan.ContactEmails)
-	}
-	if len(plan.DeploymentStages) > 0 {
-		req.DeploymentStages = typesSliceToStrings(plan.DeploymentStages)
-	}
+	req.BusinessCriticality = plan.BusinessCriticality.ValueString()
+	req.OwnerTeam = plan.OwnerTeam.ValueString()
+	req.Application = plan.Application.ValueString()
+	req.ContactEmails = typesSliceToStrings(plan.ContactEmails)
+	req.DeploymentStages = typesSliceToStrings(plan.DeploymentStages)
 }
 
 func setMetadataInState(state *businessUnitResourceModel, instance *api_client.BusinessUnit) {

--- a/orcasecurity/business_unit/resource.go
+++ b/orcasecurity/business_unit/resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -153,6 +154,10 @@ func (r *businessUnitResource) Schema(ctx context.Context, req resource.SchemaRe
 			"global_filter": schema.BoolAttribute{
 				Description: "Whether or not this is a business unit all users within your Orca org can use. If set to true, then it is accessible to all other users in your org.",
 				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"business_criticality": schema.StringAttribute{
 				Description: "Business criticality. Valid values: `low`, `medium`, `high`, `critical`.",

--- a/orcasecurity/business_unit/resource.go
+++ b/orcasecurity/business_unit/resource.go
@@ -490,6 +490,14 @@ func (r *businessUnitResource) Create(ctx context.Context, req resource.CreateRe
 	// Always set the ID from the API response
 	plan.ID = types.StringValue(instance.ID)
 
+	// Sync computed metadata back from the API response so any attribute
+	// the framework marked as unknown after planning becomes known.
+	if instance.GlobalFilter != nil {
+		plan.GlobalFilter = types.BoolValue(*instance.GlobalFilter)
+	} else {
+		plan.GlobalFilter = types.BoolValue(false)
+	}
+
 	// Set the state
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/orcasecurity/business_unit/resource.go
+++ b/orcasecurity/business_unit/resource.go
@@ -175,9 +175,12 @@ func (r *businessUnitResource) Schema(ctx context.Context, req resource.SchemaRe
 				Optional:    true,
 			},
 			"contact_emails": schema.ListAttribute{
-				Description: "Contact emails associated with the business unit.",
+				Description: "Contact emails associated with the business unit. Up to 2 values.",
 				ElementType: types.StringType,
 				Optional:    true,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(2),
+				},
 			},
 			"deployment_stages": schema.ListAttribute{
 				Description: "Deployment stages associated with the business unit. Up to 2 values.",

--- a/orcasecurity/custom_widget/resource.go
+++ b/orcasecurity/custom_widget/resource.go
@@ -11,6 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -134,6 +137,9 @@ func (r *customWidgetResource) Schema(ctx context.Context, req resource.SchemaRe
 			"view_type": schema.StringAttribute{
 				Description: "This variable is `customs_widgets` for custom widgets.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"extra_params": schema.SingleNestedAttribute{
 				Required: true,
@@ -145,6 +151,9 @@ func (r *customWidgetResource) Schema(ctx context.Context, req resource.SchemaRe
 					"category": schema.StringAttribute{
 						Description: "Should be set to 'custom' for custom dashboards.",
 						Computed:    true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"empty_state_message": schema.StringAttribute{
 						Description: "When no objects are returned by the widget's underlying Discovery query, the widget would present this message.",
@@ -161,6 +170,9 @@ func (r *customWidgetResource) Schema(ctx context.Context, req resource.SchemaRe
 					"title": schema.StringAttribute{
 						Description: "Custom widget title that will be presented in the UI.",
 						Computed:    true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"subtitle": schema.StringAttribute{
 						Description: "Custom widget subtitle that will be presented in the UI.",
@@ -231,21 +243,41 @@ func (r *customWidgetResource) Schema(ctx context.Context, req resource.SchemaRe
 										ElementType: types.StringType,
 										Description: "How to group the returned results. Do not use this option with the table-type widget",
 										Optional:    true,
+										Computed:    true,
+										PlanModifiers: []planmodifier.List{
+											listplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"limit": schema.Int64Attribute{
 										Description: "Number of items returned in query.",
 										Optional:    true,
+										Computed:    true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"order_by": schema.ListAttribute{
 										ElementType: types.StringType,
 										Description: "How the returned items are ordered.",
 										Optional:    true,
+										Computed:    true,
+										PlanModifiers: []planmodifier.List{
+											listplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"start_at_index": schema.Int64Attribute{
 										Optional: true,
+										Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"enable_pagination": schema.BoolAttribute{
 										Optional: true,
+										Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 							},

--- a/orcasecurity/discovery_view/resource.go
+++ b/orcasecurity/discovery_view/resource.go
@@ -28,6 +28,31 @@ type discoveryViewResource struct {
 	apiClient *api_client.APIClient
 }
 
+type personalViewWarningValidator struct{}
+
+func (personalViewWarningValidator) Description(_ context.Context) string {
+	return "warns when organization_level is set to false"
+}
+
+func (v personalViewWarningValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (personalViewWarningValidator) ValidateBool(_ context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	if !req.ConfigValue.ValueBool() {
+		resp.Diagnostics.AddAttributeWarning(
+			req.Path,
+			"Personal discovery view is scoped to the API token user",
+			"organization_level = false creates a personal view owned by the user identity behind the provider's API token. "+
+				"It will only appear in the Orca UI when you log in as that same user. If the token user differs from your UI user, "+
+				"the view will exist in the API but will not be visible in the UI. Set organization_level = true to share with the org.",
+		)
+	}
+}
+
 type discoveryQueryResourceModel struct {
 	Data types.String `tfsdk:"query"`
 }
@@ -324,6 +349,9 @@ func (r *discoveryViewResource) Schema(ctx context.Context, req resource.SchemaR
 					"Personal views created via Terraform therefore only appear in the UI when you log in as that token user; if your TF token user differs from your UI user, the view will exist in the API (`GET /api/user_preferences?view_type=discovery` returns it under `data.user_preferences[]`) but it will not be shown in the UI. " +
 					"For views that should be visible to multiple users, set `organization_level = true`.",
 				Required: true,
+				Validators: []validator.Bool{
+					personalViewWarningValidator{},
+				},
 			},
 			"extra_params": schema.MapAttribute{
 				Description: "Reserved for additional view parameters. To control which columns are displayed, use the `columns` attribute instead.",
@@ -439,16 +467,6 @@ func (r *discoveryViewResource) Create(ctx context.Context, req resource.CreateR
 		ViewType:          plan.ViewType.String()[1 : len(plan.ViewType.String())-1],
 		ExtraParameters:   buildExtraParams(listToStrings(ctx, plan.Columns), plan.Sort.ValueString(), planGroupByEntries(ctx, plan)),
 		FilterData:        api_client.DiscoveryQuery{Data: query},
-	}
-
-	if !plan.OrganizationLevel.ValueBool() {
-		resp.Diagnostics.AddAttributeWarning(
-			path.Root("organization_level"),
-			"Personal discovery view is scoped to the API token user",
-			"organization_level = false creates a personal view owned by the user identity behind the provider's API token. "+
-				"It will only appear in the Orca UI when you log in as that same user. If the token user differs from your UI user, "+
-				"the view will exist in the API but will not be visible in the UI. Set organization_level = true to share with the org.",
-		)
 	}
 
 	instance, err := r.apiClient.CreateDiscoveryView(createReq)

--- a/orcasecurity/discovery_view/resource.go
+++ b/orcasecurity/discovery_view/resource.go
@@ -319,8 +319,11 @@ func (r *discoveryViewResource) Schema(ctx context.Context, req resource.SchemaR
 				Required:    true,
 			},
 			"organization_level": schema.BoolAttribute{
-				Description: "If set to true, it is is a shared discovery view (can be viewed by any member of your Orca org). If set to false, it is a personal discovery view (can be viewed only by you, not other members of your Orca org).",
-				Required:    true,
+				Description: "If set to true, it is a shared discovery view (visible to every member of your Orca org). " +
+					"If set to false, it is a personal discovery view that is **scoped to the user identity behind the API token used by this provider**, not whichever user is logged into the Orca UI. " +
+					"Personal views created via Terraform therefore only appear in the UI when you log in as that token user; if your TF token user differs from your UI user, the view will exist in the API (`GET /api/user_preferences?view_type=discovery` returns it under `data.user_preferences[]`) but it will not be shown in the UI. " +
+					"For views that should be visible to multiple users, set `organization_level = true`.",
+				Required: true,
 			},
 			"extra_params": schema.MapAttribute{
 				Description: "Reserved for additional view parameters. To control which columns are displayed, use the `columns` attribute instead.",
@@ -436,6 +439,16 @@ func (r *discoveryViewResource) Create(ctx context.Context, req resource.CreateR
 		ViewType:          plan.ViewType.String()[1 : len(plan.ViewType.String())-1],
 		ExtraParameters:   buildExtraParams(listToStrings(ctx, plan.Columns), plan.Sort.ValueString(), planGroupByEntries(ctx, plan)),
 		FilterData:        api_client.DiscoveryQuery{Data: query},
+	}
+
+	if !plan.OrganizationLevel.ValueBool() {
+		resp.Diagnostics.AddAttributeWarning(
+			path.Root("organization_level"),
+			"Personal discovery view is scoped to the API token user",
+			"organization_level = false creates a personal view owned by the user identity behind the provider's API token. "+
+				"It will only appear in the Orca UI when you log in as that same user. If the token user differs from your UI user, "+
+				"the view will exist in the API but will not be visible in the UI. Set organization_level = true to share with the org.",
+		)
 	}
 
 	instance, err := r.apiClient.CreateDiscoveryView(createReq)

--- a/templates/resources/automation_v2.md.tmpl
+++ b/templates/resources/automation_v2.md.tmpl
@@ -89,8 +89,8 @@ Required:
 
 Optional:
 
-- `justification` (String) More detailed reasoning as to why these alerts are being dismissed.
-- `reason` (String) The reason these alerts are being dismissed.
+- `justification` (String) More detailed reasoning as to why these alerts are being dismissed. Optional; empty string is treated as omitted.
+- `reason` (String) The reason these alerts are being dismissed. Optional; empty string is treated as omitted.
 
 <a id="nestedatt--alert_score_decrease_details"></a>
 
@@ -98,8 +98,8 @@ Optional:
 
 Optional:
 
-- `justification` (String) More detailed reasoning as to why these alerts are having their score changed.
-- `reason` (String) The reason these alerts are having their score decreased.
+- `justification` (String) More detailed reasoning as to why these alerts are having their score changed. Optional; empty string is treated as omitted.
+- `reason` (String) The reason these alerts are having their score decreased. Optional; empty string is treated as omitted.
 
 <a id="nestedatt--alert_score_increase_details"></a>
 
@@ -107,8 +107,8 @@ Optional:
 
 Optional:
 
-- `justification` (String) More detailed reasoning as to why these alerts are having their score changed.
-- `reason` (String) The reason these alerts are having their score increased.
+- `justification` (String) More detailed reasoning as to why these alerts are having their score changed. Optional; empty string is treated as omitted.
+- `reason` (String) The reason these alerts are having their score increased. Optional; empty string is treated as omitted.
 
 <a id="nestedatt--alert_score_specify_details"></a>
 
@@ -120,8 +120,8 @@ Required:
 
 Optional:
 
-- `justification` (String) More detailed reasoning as to why these alerts are having their score changed.
-- `reason` (String) The reason these alerts are having their score changed.
+- `justification` (String) More detailed reasoning as to why these alerts are having their score changed. Optional; empty string is treated as omitted.
+- `reason` (String) The reason these alerts are having their score changed. Optional; empty string is treated as omitted.
 
 <a id="nestedatt--aws_security_hub_template"></a>
 
@@ -339,8 +339,8 @@ Required:
 
 Optional:
 
-- `justification` (String) Justification for snoozing.
-- `reason` (String) Reason for snoozing.
+- `justification` (String) Justification for snoozing. Optional; empty string is treated as omitted.
+- `reason` (String) Reason for snoozing. Optional; empty string is treated as omitted.
 
 <a id="nestedatt--snowflake_template"></a>
 

--- a/templates/resources/business_unit.md.tmpl
+++ b/templates/resources/business_unit.md.tmpl
@@ -33,7 +33,7 @@ Please note that a business unit cannot be composed of multiple, different filte
 
 - `application` (String) Application or product line the business unit represents.
 - `business_criticality` (String) Business criticality. Valid values: `low`, `medium`, `high`, `critical`.
-- `contact_emails` (List of String) Contact emails associated with the business unit.
+- `contact_emails` (List of String) Contact emails associated with the business unit. Up to 2 values.
 - `deployment_stages` (List of String) Deployment stages associated with the business unit. Up to 2 values.
 - `filter_data` (Attributes) The filter to select the resources of the business unit. If you are creating a BU that only includes Shift Left resources (projects), this can be safely excluded. (see [below for nested schema](#nestedatt--filter_data))
 - `global_filter` (Boolean) Whether or not this is a business unit all users within your Orca org can use. If set to true, then it is accessible to all other users in your org.

--- a/templates/resources/business_unit.md.tmpl
+++ b/templates/resources/business_unit.md.tmpl
@@ -31,8 +31,13 @@ Please note that a business unit cannot be composed of multiple, different filte
 
 ### Optional
 
+- `application` (String) Application or product line the business unit represents.
+- `business_criticality` (String) Business criticality. Valid values: `low`, `medium`, `high`, `critical`.
+- `contact_emails` (List of String) Contact emails associated with the business unit.
+- `deployment_stages` (List of String) Deployment stages associated with the business unit. Up to 2 values.
 - `filter_data` (Attributes) The filter to select the resources of the business unit. If you are creating a BU that only includes Shift Left resources (projects), this can be safely excluded. (see [below for nested schema](#nestedatt--filter_data))
 - `global_filter` (Boolean) Whether or not this is a business unit all users within your Orca org can use. If set to true, then it is accessible to all other users in your org.
+- `owner_team` (String) Owning team or department for the business unit.
 - `shiftleft_filter_data` (Attributes) The filter to select Shift Left resources for the business unit. If you are creating a BU that only includes Shift Left resources (projects), this can be safely excluded. (see [below for nested schema](#nestedatt--shiftleft_filter_data))
 
 ### Read-Only


### PR DESCRIPTION
## Summary
- **automation_v2**: align provider with API contract — `reason` and `justification` on `alert_dismissal_details`, `snooze_template`, and the three `alert_score_*_details` blocks now treat empty strings as omitted instead of forwarding them (API rejects empty values).
- **automation_v2 refactor**: collapse duplicated action-building code in `generateV2Actions` via `appendExternalConfigAction`, `appendExternalConfigWithParentAction`, and `appendReasonJustificationAction` helpers. Extract repeated description literal into a constant.
- **business_unit — missing optional attrs**: expose `business_criticality` (enum: low/medium/high/critical), `owner_team`, `application`, `contact_emails`, `deployment_stages` (max 2). Wire `global_filter` through to the API (previously declared in schema but never sent).
- **business_unit — Update bug**: add fall-through branch so metadata-only changes propagate even when no filter attribute changes (previously the Update silently no-op'd).
- **custom_widget — perpetual diff fix**: add `UseStateForUnknown` plan modifiers on computed `view_type`/`category`/`title`, and promote `request_params` numeric/list fields (`limit`, `start_at_index`, `enable_pagination`, `group_by_list`, `order_by`) to Optional+Computed with `UseStateForUnknown` to stop endless `terraform apply` diffs.

