### PR TITLE
fix(rbac-access): stop group/user access re-creation and silent-delete (#261)

### DIFF
--- a/docs/resources/group_access.md
+++ b/docs/resources/group_access.md
@@ -63,9 +63,7 @@ resource "orcasecurity_group" "example" {
 
 ## Import
 
-Import is supported using the following syntax:
-
-The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+Import is supported using the following syntax (id = Orca assignment id):
 
 ```shell
 terraform import orcasecurity_group_access.example ASSIGNMENT_ID

--- a/docs/resources/group_access.md
+++ b/docs/resources/group_access.md
@@ -60,3 +60,13 @@ resource "orcasecurity_group" "example" {
 ### Read-Only
 
 - `id` (String) Orca assignment id returned by the API.
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import orcasecurity_group_access.example ASSIGNMENT_ID
+```

--- a/docs/resources/group_access.md
+++ b/docs/resources/group_access.md
@@ -63,7 +63,9 @@ resource "orcasecurity_group" "example" {
 
 ## Import
 
-Import is supported using the following syntax (id = Orca assignment id):
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 terraform import orcasecurity_group_access.example ASSIGNMENT_ID

--- a/docs/resources/user_access.md
+++ b/docs/resources/user_access.md
@@ -55,3 +55,11 @@ resource "orcasecurity_business_unit" "example" {
 ### Read-Only
 
 - `id` (String) Orca assignment id returned by the API.
+
+## Import
+
+Import is supported using the following syntax. The id is the Orca assignment id (the `id` attribute of the resource).
+
+```shell
+terraform import orcasecurity_user_access.example ASSIGNMENT_ID
+```

--- a/docs/resources/user_access.md
+++ b/docs/resources/user_access.md
@@ -58,7 +58,7 @@ resource "orcasecurity_business_unit" "example" {
 
 ## Import
 
-Import is supported using the following syntax. The id is the Orca assignment id (the `id` attribute of the resource).
+Import is supported using the following syntax (id = Orca assignment id):
 
 ```shell
 terraform import orcasecurity_user_access.example ASSIGNMENT_ID

--- a/examples/resources/orcasecurity_group_access/import.sh
+++ b/examples/resources/orcasecurity_group_access/import.sh
@@ -1,0 +1,1 @@
+terraform import orcasecurity_group_access.example ASSIGNMENT_ID

--- a/examples/resources/orcasecurity_user_access/import.sh
+++ b/examples/resources/orcasecurity_user_access/import.sh
@@ -1,0 +1,1 @@
+terraform import orcasecurity_user_access.example ASSIGNMENT_ID

--- a/orcasecurity/api_client/group_access.go
+++ b/orcasecurity/api_client/group_access.go
@@ -10,17 +10,11 @@ import (
 	"strings"
 )
 
-// The endpoint has no /<id> route (GET/PUT/DELETE on /<id> all 404): the id
-// travels in the request body, and reads page the collection and filter
-// client-side because the server ignores the group_id/id query params.
+// No /<id> route: id in body. Group list paginates (default 10) — page all, filter client-side.
 const (
 	apiRBACGroupAccessPath = "/api/rbac/access/group"
-	// rbacAccessPageLimit is the page size for the group list, which paginates
-	// (default 10 rows) and honours limit + start_at_index.
-	rbacAccessPageLimit = 300
-	// rbacAccessMaxLimit is a single-request ceiling for the user list, which
-	// ignores start_at_index and returns the whole collection at once.
-	rbacAccessMaxLimit = 10000
+	rbacAccessPageLimit    = 300
+	rbacAccessMaxLimit     = 10000 // user list is one-shot, not offset-pageable
 )
 
 type GroupAccess struct {
@@ -175,15 +169,10 @@ func pickMatchingGroupAccess(list []GroupAccess, groupID string, want GroupAcces
 	return &picked
 }
 
-// pageAllGroupAccess pages the whole /api/rbac/access/group collection. The
-// server ignores the group_id query param and paginates (default 10 rows), so
-// every page must be fetched and filtered client-side.
 func (client *APIClient) pageAllGroupAccess() ([]GroupAccess, error) {
 	var out []GroupAccess
 	fetched := 0
 	for {
-		// Offset by rows received, not page count, so a short page under-fetches
-		// safely instead of skipping rows.
 		q := url.Values{}
 		q.Set("limit", strconv.Itoa(rbacAccessPageLimit))
 		q.Set("start_at_index", strconv.Itoa(fetched))
@@ -223,9 +212,6 @@ func (client *APIClient) ListGroupAccessForGroup(groupID string) ([]GroupAccess,
 	return out, nil
 }
 
-// FindGroupAccess returns the row matching assignmentID, falling back to
-// role+scope when the id has changed server-side. When want.GroupID is unset
-// (import, where only the id is known) it scans the whole collection.
 func (client *APIClient) FindGroupAccess(assignmentID string, want GroupAccess) (*GroupAccess, error) {
 	var list []GroupAccess
 	var err error
@@ -247,8 +233,6 @@ func (client *APIClient) FindGroupAccess(assignmentID string, want GroupAccess) 
 	return pickMatchingGroupAccess(list, want.GroupID, want), nil
 }
 
-// UpdateGroupAccess updates an existing assignment. The id is carried in the
-// body; the PUT response nests group/role, so re-read the canonical row.
 func (client *APIClient) UpdateGroupAccess(data GroupAccess) (*GroupAccess, error) {
 	if data.ID == "" {
 		return nil, fmt.Errorf("update group access: id is required")

--- a/orcasecurity/api_client/group_access.go
+++ b/orcasecurity/api_client/group_access.go
@@ -6,15 +6,23 @@ import (
 	"net/url"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 )
 
+// The endpoint has no /<id> route (GET/PUT/DELETE on /<id> all 404): the id
+// travels in the request body, and reads page the collection and filter
+// client-side because the server ignores the group_id/id query params.
 const (
-	apiRBACGroupAccessPath    = "/api/rbac/access/group"
-	apiRBACGroupAccessByIDFmt = "/api/rbac/access/group/%s"
+	apiRBACGroupAccessPath = "/api/rbac/access/group"
+	// rbacAccessPageLimit is the page size for the group list, which paginates
+	// (default 10 rows) and honours limit + start_at_index.
+	rbacAccessPageLimit = 300
+	// rbacAccessMaxLimit is a single-request ceiling for the user list, which
+	// ignores start_at_index and returns the whole collection at once.
+	rbacAccessMaxLimit = 10000
 )
 
-// GroupAccess maps to POST/PUT /api/rbac/access/group payloads.
 type GroupAccess struct {
 	ID                string   `json:"id,omitempty"`
 	AllCloudAccounts  bool     `json:"all_cloud_accounts"`
@@ -58,28 +66,6 @@ func (client *APIClient) CreateGroupAccess(data GroupAccess) (*GroupAccess, erro
 	}
 
 	return nil, fmt.Errorf("create group access: could not parse assignment id from response: %s", string(body))
-}
-
-// GetGroupAccess fetches a group–role assignment by its Orca assignment id.
-func (client *APIClient) GetGroupAccess(id string) (*GroupAccess, error) {
-	resp, err := client.Get(fmt.Sprintf(apiRBACGroupAccessByIDFmt, id))
-	if err != nil {
-		if strings.Contains(err.Error(), "status: 404") {
-			return nil, nil
-		}
-		return nil, err
-	}
-	body := resp.Body()
-
-	var wrapped groupAccessAPIResponseType
-	if err := json.Unmarshal(body, &wrapped); err != nil {
-		return nil, err
-	}
-	out := wrapped.Data
-	if out.ID == "" {
-		out.ID = id
-	}
-	return &out, nil
 }
 
 type groupAccessListRow struct {
@@ -189,81 +175,101 @@ func pickMatchingGroupAccess(list []GroupAccess, groupID string, want GroupAcces
 	return &picked
 }
 
-// ListGroupAccessForGroup calls GET /api/rbac/access/group?group_id=… and returns rows whose
-// nested group id equals groupID (the API may include other groups in the payload).
+// pageAllGroupAccess pages the whole /api/rbac/access/group collection. The
+// server ignores the group_id query param and paginates (default 10 rows), so
+// every page must be fetched and filtered client-side.
+func (client *APIClient) pageAllGroupAccess() ([]GroupAccess, error) {
+	var out []GroupAccess
+	fetched := 0
+	for {
+		// Offset by rows received, not page count, so a short page under-fetches
+		// safely instead of skipping rows.
+		q := url.Values{}
+		q.Set("limit", strconv.Itoa(rbacAccessPageLimit))
+		q.Set("start_at_index", strconv.Itoa(fetched))
+		resp, err := client.Get(apiRBACGroupAccessPath + "?" + q.Encode())
+		if err != nil {
+			return nil, err
+		}
+		var envelope struct {
+			TotalItems int                  `json:"total_items"`
+			Data       []groupAccessListRow `json:"data"`
+		}
+		if err := json.Unmarshal(resp.Body(), &envelope); err != nil {
+			return nil, err
+		}
+		for _, row := range envelope.Data {
+			out = append(out, groupAccessFromListRow(row))
+		}
+		fetched += len(envelope.Data)
+		if len(envelope.Data) == 0 || fetched >= envelope.TotalItems {
+			return out, nil
+		}
+	}
+}
+
+// ListGroupAccessForGroup returns the assignments whose nested group id equals groupID.
 func (client *APIClient) ListGroupAccessForGroup(groupID string) ([]GroupAccess, error) {
-	q := url.Values{}
-	q.Set("group_id", groupID)
-	path := apiRBACGroupAccessPath + "?" + q.Encode()
-	resp, err := client.Get(path)
+	all, err := client.pageAllGroupAccess()
 	if err != nil {
 		return nil, err
 	}
-	body := resp.Body()
-	var envelope struct {
-		Data []groupAccessListRow `json:"data"`
-	}
-	if err := json.Unmarshal(body, &envelope); err != nil {
-		return nil, err
-	}
-	out := make([]GroupAccess, 0, len(envelope.Data))
-	for _, row := range envelope.Data {
-		ga := groupAccessFromListRow(row)
-		if ga.GroupID != groupID {
-			continue
+	out := make([]GroupAccess, 0, len(all))
+	for _, ga := range all {
+		if ga.GroupID == groupID {
+			out = append(out, ga)
 		}
-		out = append(out, ga)
 	}
 	return out, nil
 }
 
-// FindGroupAccess resolves an assignment by id via GET; if that returns 404, it lists
-// assignments for want.GroupID and returns the row matching role and scope (same as want).
-// want.ID is used only to break ties when multiple API rows match the same scope.
+// FindGroupAccess returns the row matching assignmentID, falling back to
+// role+scope when the id has changed server-side. When want.GroupID is unset
+// (import, where only the id is known) it scans the whole collection.
 func (client *APIClient) FindGroupAccess(assignmentID string, want GroupAccess) (*GroupAccess, error) {
-	byID, err := client.GetGroupAccess(assignmentID)
-	if err != nil {
-		return nil, err
-	}
-	if byID != nil {
-		return byID, nil
-	}
+	var list []GroupAccess
+	var err error
 	if want.GroupID == "" {
-		return nil, nil
+		list, err = client.pageAllGroupAccess()
+	} else {
+		list, err = client.ListGroupAccessForGroup(want.GroupID)
 	}
-	list, err := client.ListGroupAccessForGroup(want.GroupID)
 	if err != nil {
 		return nil, err
+	}
+	for _, item := range list {
+		if item.ID == assignmentID {
+			picked := item
+			return &picked, nil
+		}
 	}
 	want.ID = assignmentID
 	return pickMatchingGroupAccess(list, want.GroupID, want), nil
 }
 
-// UpdateGroupAccess updates an existing assignment (same payload shape as create).
+// UpdateGroupAccess updates an existing assignment. The id is carried in the
+// body; the PUT response nests group/role, so re-read the canonical row.
 func (client *APIClient) UpdateGroupAccess(data GroupAccess) (*GroupAccess, error) {
 	if data.ID == "" {
 		return nil, fmt.Errorf("update group access: id is required")
 	}
-	resp, err := client.Put(fmt.Sprintf(apiRBACGroupAccessByIDFmt, data.ID), data)
+	if _, err := client.Put(apiRBACGroupAccessPath, data); err != nil {
+		return nil, err
+	}
+	refreshed, err := client.FindGroupAccess(data.ID, data)
 	if err != nil {
 		return nil, err
 	}
-	body := resp.Body()
-
-	var wrapped groupAccessAPIResponseType
-	if err := json.Unmarshal(body, &wrapped); err != nil {
-		return nil, err
+	if refreshed != nil {
+		return refreshed, nil
 	}
-	out := wrapped.Data
-	if out.ID == "" {
-		out.ID = data.ID
-	}
+	out := data
 	return &out, nil
 }
 
-// DeleteGroupAccess removes a group–role assignment.
+// DeleteGroupAccess removes a group–role assignment (id carried in the body).
 func (client *APIClient) DeleteGroupAccess(id string) error {
-	_, err := client.Delete(fmt.Sprintf(apiRBACGroupAccessByIDFmt, id))
+	_, err := client.DeleteWithBody(apiRBACGroupAccessPath, map[string]string{"id": id})
 	if err != nil && strings.Contains(err.Error(), "status: 404") {
 		return nil
 	}

--- a/orcasecurity/api_client/group_access.go
+++ b/orcasecurity/api_client/group_access.go
@@ -1,261 +1,95 @@
 package api_client
 
-import (
-	"encoding/json"
-	"fmt"
-	"net/url"
-	"slices"
-	"sort"
-	"strconv"
-	"strings"
-)
+const apiRBACGroupAccessPath = "/api/rbac/access/group"
 
-// No /<id> route: id in body. Group list paginates (default 10) — page all, filter client-side.
-const (
-	apiRBACGroupAccessPath = "/api/rbac/access/group"
-	rbacAccessPageLimit    = 300
-	rbacAccessMaxLimit     = 10000 // user list is one-shot, not offset-pageable
-)
-
-type GroupAccess struct {
-	ID                string   `json:"id,omitempty"`
-	AllCloudAccounts  bool     `json:"all_cloud_accounts"`
-	RoleID            string   `json:"role_id"`
-	GroupID           string   `json:"group_id"`
-	CloudAccounts     []string `json:"cloud_accounts"`
-	ShiftleftProjects []string `json:"shiftleft_projects"`
-	UserFilters       []string `json:"user_filters"`
+var groupAccessEndpoint = rbacAccessEndpoint{
+	path:      apiRBACGroupAccessPath,
+	ownerKey:  "group",
+	paginated: true,
 }
 
-type groupAccessAPIResponseType struct {
-	Data GroupAccess `json:"data"`
+// GroupAccess is the public DTO for a group–role assignment. The shared engine
+// in rbac_access.go does the transport; this type just names the group-facing
+// fields the resource layer reads.
+type GroupAccess struct {
+	ID                string
+	AllCloudAccounts  bool
+	RoleID            string
+	GroupID           string
+	CloudAccounts     []string
+	ShiftleftProjects []string
+	UserFilters       []string
+}
+
+func (g GroupAccess) toRecord() rbacAccessRecord {
+	return rbacAccessRecord{
+		ID:                g.ID,
+		OwnerID:           g.GroupID,
+		RoleID:            g.RoleID,
+		AllCloudAccounts:  g.AllCloudAccounts,
+		CloudAccounts:     g.CloudAccounts,
+		ShiftleftProjects: g.ShiftleftProjects,
+		UserFilters:       g.UserFilters,
+	}
+}
+
+func groupAccessFromRecord(r rbacAccessRecord) GroupAccess {
+	return GroupAccess{
+		ID:                r.ID,
+		GroupID:           r.OwnerID,
+		RoleID:            r.RoleID,
+		AllCloudAccounts:  r.AllCloudAccounts,
+		CloudAccounts:     r.CloudAccounts,
+		ShiftleftProjects: r.ShiftleftProjects,
+		UserFilters:       r.UserFilters,
+	}
 }
 
 // CreateGroupAccess assigns a role to a group with optional cloud account, Shift Left, or user filter (e.g. business unit) scope.
 func (client *APIClient) CreateGroupAccess(data GroupAccess) (*GroupAccess, error) {
-	resp, err := client.Post(apiRBACGroupAccessPath, data)
+	id, err := client.createAccess(groupAccessEndpoint, data.toRecord())
 	if err != nil {
 		return nil, err
 	}
-	body := resp.Body()
-
-	var wrapped groupAccessAPIResponseType
-	if err := json.Unmarshal(body, &wrapped); err == nil && wrapped.Data.ID != "" {
-		return &wrapped.Data, nil
-	}
-
-	var envelope struct {
-		Data json.RawMessage `json:"data"`
-	}
-	if err := json.Unmarshal(body, &envelope); err == nil && len(envelope.Data) > 0 {
-		var withID GroupAccess
-		if err := json.Unmarshal(envelope.Data, &withID); err == nil && withID.ID != "" {
-			return &withID, nil
-		}
-	}
-
-	var direct GroupAccess
-	if err := json.Unmarshal(body, &direct); err == nil && direct.ID != "" {
-		return &direct, nil
-	}
-
-	return nil, fmt.Errorf("create group access: could not parse assignment id from response: %s", string(body))
-}
-
-type groupAccessListRow struct {
-	ID               string          `json:"id"`
-	AllCloudAccounts bool            `json:"all_cloud_accounts"`
-	Group            groupAccessRef  `json:"group"`
-	Role             groupAccessRef  `json:"role"`
-	CloudAccounts    []cloudAcctRef  `json:"cloud_accounts"`
-	UserFilters      []string        `json:"user_filters"`
-	ShiftleftRaw     json.RawMessage `json:"shiftleft_projects"`
-}
-
-type groupAccessRef struct {
-	ID string `json:"id"`
-}
-
-type cloudAcctRef struct {
-	ID string `json:"id"`
-}
-
-func parseShiftleftProjectIDs(raw json.RawMessage) []string {
-	if len(raw) == 0 || string(raw) == "null" {
-		return nil
-	}
-	var strs []string
-	if err := json.Unmarshal(raw, &strs); err == nil {
-		return strs
-	}
-	var objs []struct {
-		ID string `json:"id"`
-	}
-	if err := json.Unmarshal(raw, &objs); err != nil {
-		return nil
-	}
-	out := make([]string, 0, len(objs))
-	for _, o := range objs {
-		if o.ID != "" {
-			out = append(out, o.ID)
-		}
-	}
-	return out
-}
-
-func groupAccessFromListRow(row groupAccessListRow) GroupAccess {
-	cloudIDs := make([]string, 0, len(row.CloudAccounts))
-	for _, ca := range row.CloudAccounts {
-		if ca.ID != "" {
-			cloudIDs = append(cloudIDs, ca.ID)
-		}
-	}
-	return GroupAccess{
-		ID:                row.ID,
-		GroupID:           row.Group.ID,
-		RoleID:            row.Role.ID,
-		AllCloudAccounts:  row.AllCloudAccounts,
-		CloudAccounts:     cloudIDs,
-		ShiftleftProjects: parseShiftleftProjectIDs(row.ShiftleftRaw),
-		UserFilters:       row.UserFilters,
-	}
-}
-
-func normalizeStringSliceForCompare(s []string) []string {
-	if len(s) == 0 {
-		return nil
-	}
-	out := append([]string(nil), s...)
-	sort.Strings(out)
-	return out
-}
-
-func stringSliceSetEqual(a, b []string) bool {
-	return slices.Equal(normalizeStringSliceForCompare(a), normalizeStringSliceForCompare(b))
-}
-
-// groupAccessScopesMatch compares role and scope fields (not assignment id).
-func groupAccessScopesMatch(want, got GroupAccess) bool {
-	return want.RoleID == got.RoleID &&
-		want.AllCloudAccounts == got.AllCloudAccounts &&
-		stringSliceSetEqual(want.CloudAccounts, got.CloudAccounts) &&
-		stringSliceSetEqual(want.ShiftleftProjects, got.ShiftleftProjects) &&
-		stringSliceSetEqual(want.UserFilters, got.UserFilters)
-}
-
-func pickMatchingGroupAccess(list []GroupAccess, groupID string, want GroupAccess) *GroupAccess {
-	var matches []GroupAccess
-	for _, item := range list {
-		if item.GroupID != groupID {
-			continue
-		}
-		if !groupAccessScopesMatch(want, item) {
-			continue
-		}
-		matches = append(matches, item)
-	}
-	if len(matches) == 0 {
-		return nil
-	}
-	if want.ID != "" {
-		for _, m := range matches {
-			if m.ID == want.ID {
-				picked := m
-				return &picked
-			}
-		}
-	}
-	picked := matches[0]
-	return &picked
-}
-
-func (client *APIClient) pageAllGroupAccess() ([]GroupAccess, error) {
-	var out []GroupAccess
-	fetched := 0
-	for {
-		q := url.Values{}
-		q.Set("limit", strconv.Itoa(rbacAccessPageLimit))
-		q.Set("start_at_index", strconv.Itoa(fetched))
-		resp, err := client.Get(apiRBACGroupAccessPath + "?" + q.Encode())
-		if err != nil {
-			return nil, err
-		}
-		var envelope struct {
-			TotalItems int                  `json:"total_items"`
-			Data       []groupAccessListRow `json:"data"`
-		}
-		if err := json.Unmarshal(resp.Body(), &envelope); err != nil {
-			return nil, err
-		}
-		for _, row := range envelope.Data {
-			out = append(out, groupAccessFromListRow(row))
-		}
-		fetched += len(envelope.Data)
-		if len(envelope.Data) == 0 || fetched >= envelope.TotalItems {
-			return out, nil
-		}
-	}
+	out := data
+	out.ID = id
+	return &out, nil
 }
 
 // ListGroupAccessForGroup returns the assignments whose nested group id equals groupID.
 func (client *APIClient) ListGroupAccessForGroup(groupID string) ([]GroupAccess, error) {
-	all, err := client.pageAllGroupAccess()
+	records, err := client.listAccessForOwner(groupAccessEndpoint, groupID)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]GroupAccess, 0, len(all))
-	for _, ga := range all {
-		if ga.GroupID == groupID {
-			out = append(out, ga)
-		}
+	out := make([]GroupAccess, 0, len(records))
+	for _, r := range records {
+		out = append(out, groupAccessFromRecord(r))
 	}
 	return out, nil
 }
 
+// FindGroupAccess resolves an assignment by id (preferred) or role+scope fallback; nil when nothing matches.
 func (client *APIClient) FindGroupAccess(assignmentID string, want GroupAccess) (*GroupAccess, error) {
-	var list []GroupAccess
-	var err error
-	if want.GroupID == "" {
-		list, err = client.pageAllGroupAccess()
-	} else {
-		list, err = client.ListGroupAccessForGroup(want.GroupID)
-	}
-	if err != nil {
+	rec, err := client.findAccess(groupAccessEndpoint, assignmentID, want.toRecord())
+	if err != nil || rec == nil {
 		return nil, err
 	}
-	for _, item := range list {
-		if item.ID == assignmentID {
-			picked := item
-			return &picked, nil
-		}
-	}
-	want.ID = assignmentID
-	return pickMatchingGroupAccess(list, want.GroupID, want), nil
+	out := groupAccessFromRecord(*rec)
+	return &out, nil
 }
 
+// UpdateGroupAccess updates an existing assignment (id carried in the body).
 func (client *APIClient) UpdateGroupAccess(data GroupAccess) (*GroupAccess, error) {
-	if data.ID == "" {
-		return nil, fmt.Errorf("update group access: id is required")
-	}
-	if _, err := client.Put(apiRBACGroupAccessPath, data); err != nil {
-		return nil, err
-	}
-	refreshed, err := client.FindGroupAccess(data.ID, data)
+	rec, err := client.updateAccess(groupAccessEndpoint, data.toRecord())
 	if err != nil {
 		return nil, err
 	}
-	if refreshed != nil {
-		return refreshed, nil
-	}
-	out := data
+	out := groupAccessFromRecord(*rec)
 	return &out, nil
 }
 
 // DeleteGroupAccess removes a group–role assignment (id carried in the body).
 func (client *APIClient) DeleteGroupAccess(id string) error {
-	_, err := client.DeleteWithBody(apiRBACGroupAccessPath, map[string]string{"id": id})
-	if err != nil && strings.Contains(err.Error(), "status: 404") {
-		return nil
-	}
-	return err
+	return client.deleteAccess(groupAccessEndpoint, id)
 }

--- a/orcasecurity/api_client/group_access_test.go
+++ b/orcasecurity/api_client/group_access_test.go
@@ -61,8 +61,7 @@ func TestListGroupAccessForGroup_FiltersByNestedGroupID(t *testing.T) {
 	}
 }
 
-// The target grant lives on page 2 (start_at_index > 0); before pagination the
-// read only saw page 1 and reported it "gone".
+// Grant on page 2 — pagination must not stop at page 1.
 func TestListGroupAccessForGroup_PagesUntilTotalItems(t *testing.T) {
 	const targetGroupID = "g-target"
 
@@ -105,8 +104,7 @@ func TestListGroupAccessForGroup_PagesUntilTotalItems(t *testing.T) {
 	}
 }
 
-// FindGroupAccess must resolve a grant whose id changed server-side by matching
-// role+scope, and must never hit a by-id URL (that route 404s).
+// No by-id URL; match by role+scope when id changed.
 func TestFindGroupAccess_MatchesByScopeAcrossPages(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != apiRBACGroupAccessPath {
@@ -144,8 +142,7 @@ func TestFindGroupAccess_MatchesByScopeAcrossPages(t *testing.T) {
 	}
 }
 
-// On import only the id is known (want.GroupID empty); Find must scan the whole
-// collection and still resolve the grant.
+// Import: only assignment id known — scan whole collection.
 func TestFindGroupAccess_ScansAllWhenGroupUnknown(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -224,8 +221,6 @@ func TestCreateGroupAccess_ParsesWrappedDataID(t *testing.T) {
 	}
 }
 
-// Update PUTs to the collection path with the id in the body (never /<id>) and
-// re-reads the canonical row, since the PUT response nests group/role.
 func TestUpdateGroupAccess_UsesCollectionPathAndReReads(t *testing.T) {
 	var putBody map[string]interface{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -272,8 +267,7 @@ func TestUpdateGroupAccess_RequiresID(t *testing.T) {
 	}
 }
 
-// Delete must DELETE the collection path with body {"id": …}; the by-id URL 404s
-// and silently deletes nothing.
+// Delete: id in body on collection path (by-id URL 404s).
 func TestDeleteGroupAccess_UsesBodyNotByID(t *testing.T) {
 	var gotPath, gotMethod string
 	var gotBody map[string]string

--- a/orcasecurity/api_client/group_access_test.go
+++ b/orcasecurity/api_client/group_access_test.go
@@ -21,10 +21,8 @@ func TestListGroupAccessForGroup_FiltersByNestedGroupID(t *testing.T) {
 		if r.Method != http.MethodGet || r.URL.Path != apiRBACGroupAccessPath {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
-		if r.URL.Query().Get("group_id") != targetGroupID {
-			t.Fatalf("query group_id = %q", r.URL.Query().Get("group_id"))
-		}
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"total_items": 2,
 			"data": []map[string]interface{}{
 				{
 					"id": "asg-other", "all_cloud_accounts": true,
@@ -63,39 +61,72 @@ func TestListGroupAccessForGroup_FiltersByNestedGroupID(t *testing.T) {
 	}
 }
 
-func TestFindGroupAccess_FallsBackToListOn404(t *testing.T) {
+// The target grant lives on page 2 (start_at_index > 0); before pagination the
+// read only saw page 1 and reported it "gone".
+func TestListGroupAccessForGroup_PagesUntilTotalItems(t *testing.T) {
+	const targetGroupID = "g-target"
+
+	var starts []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/rbac/access/group/stale-id":
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = io.WriteString(w, `{"message":"not found"}`)
-		case r.Method == http.MethodGet && r.URL.Path == apiRBACGroupAccessPath:
-			if r.URL.Query().Get("group_id") != "g1" {
-				t.Fatalf("group_id %q", r.URL.Query().Get("group_id"))
-			}
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"data": []map[string]interface{}{
-					{
-						"id": "asg-live", "all_cloud_accounts": false,
-						"group":              map[string]string{"id": "g1"},
-						"role":               map[string]string{"id": "r1"},
-						"cloud_accounts":     []interface{}{},
-						"user_filters":       []string{"bu1"},
-						"shiftleft_projects": []string{},
-					},
-				},
-			})
-		default:
-			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		start := r.URL.Query().Get("start_at_index")
+		starts = append(starts, start)
+		if r.URL.Query().Get("limit") == "" {
+			t.Fatalf("expected an explicit limit, got none")
 		}
+		var rows []map[string]interface{}
+		if start == "0" || start == "" {
+			rows = []map[string]interface{}{{
+				"id": "asg-other", "group": map[string]string{"id": "g-other"},
+				"role": map[string]string{"id": "r1"},
+			}}
+		} else {
+			rows = []map[string]interface{}{{
+				"id": "asg-want", "group": map[string]string{"id": targetGroupID},
+				"role": map[string]string{"id": "r2"},
+			}}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"total_items": 2,
+			"data":        rows,
+		})
 	}))
 	defer srv.Close()
 
-	c := &APIClient{
-		APIEndpoint: srv.URL,
-		APIToken:    "tok",
-		HTTPClient:  srv.Client(),
+	c := &APIClient{APIEndpoint: srv.URL, APIToken: "tok", HTTPClient: srv.Client()}
+	got, err := c.ListGroupAccessForGroup(targetGroupID)
+	if err != nil {
+		t.Fatal(err)
 	}
+	if len(got) != 1 || got[0].ID != "asg-want" {
+		t.Fatalf("target row on a later page not returned: %+v", got)
+	}
+	if len(starts) < 2 || starts[1] != "1" {
+		t.Fatalf("expected offset to advance by rows received, got starts=%v", starts)
+	}
+}
+
+// FindGroupAccess must resolve a grant whose id changed server-side by matching
+// role+scope, and must never hit a by-id URL (that route 404s).
+func TestFindGroupAccess_MatchesByScopeAcrossPages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != apiRBACGroupAccessPath {
+			t.Fatalf("unexpected path %s (by-id routes 404)", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"total_items": 1,
+			"data": []map[string]interface{}{{
+				"id": "asg-new", "all_cloud_accounts": false,
+				"group":              map[string]string{"id": "g1"},
+				"role":               map[string]string{"id": "r1"},
+				"cloud_accounts":     []interface{}{},
+				"user_filters":       []string{"bu1"},
+				"shiftleft_projects": []string{},
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	c := &APIClient{APIEndpoint: srv.URL, APIToken: "tok", HTTPClient: srv.Client()}
 	want := GroupAccess{
 		GroupID:           "g1",
 		RoleID:            "r1",
@@ -108,8 +139,48 @@ func TestFindGroupAccess_FallsBackToListOn404(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got == nil || got.ID != "asg-live" {
+	if got == nil || got.ID != "asg-new" {
 		t.Fatalf(errFmtTestGotValue, got)
+	}
+}
+
+// On import only the id is known (want.GroupID empty); Find must scan the whole
+// collection and still resolve the grant.
+func TestFindGroupAccess_ScansAllWhenGroupUnknown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"total_items": 2,
+			"data": []map[string]interface{}{
+				{"id": "asg-other", "group": map[string]string{"id": "g-other"}, "role": map[string]string{"id": "r9"}},
+				{"id": "asg-import", "group": map[string]string{"id": "g1"}, "role": map[string]string{"id": "r1"}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := &APIClient{APIEndpoint: srv.URL, APIToken: "tok", HTTPClient: srv.Client()}
+	got, err := c.FindGroupAccess("asg-import", GroupAccess{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.ID != "asg-import" || got.GroupID != "g1" {
+		t.Fatalf(errFmtTestGotValue, got)
+	}
+}
+
+func TestFindGroupAccess_NotFoundReturnsNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"total_items": 0, "data": []interface{}{}})
+	}))
+	defer srv.Close()
+
+	c := &APIClient{APIEndpoint: srv.URL, APIToken: "tok", HTTPClient: srv.Client()}
+	got, err := c.FindGroupAccess("gone", GroupAccess{GroupID: "g1", RoleID: "r1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf(errFmtTestExpectedNilGot, got)
 	}
 }
 
@@ -153,57 +224,76 @@ func TestCreateGroupAccess_ParsesWrappedDataID(t *testing.T) {
 	}
 }
 
-func TestGetGroupAccess_404ReturnsNil(t *testing.T) {
+// Update PUTs to the collection path with the id in the body (never /<id>) and
+// re-reads the canonical row, since the PUT response nests group/role.
+func TestUpdateGroupAccess_UsesCollectionPathAndReReads(t *testing.T) {
+	var putBody map[string]interface{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = io.WriteString(w, `{"message":"not found"}`)
+		if r.URL.Path != apiRBACGroupAccessPath {
+			t.Fatalf("unexpected path %s (by-id routes 404)", r.URL.Path)
+		}
+		switch r.Method {
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &putBody)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "success", "data": map[string]interface{}{}})
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"total_items": 1,
+				"data": []map[string]interface{}{{
+					"id": "asg-1", "group": map[string]string{"id": "g1"},
+					"role": map[string]string{"id": "r2"},
+				}},
+			})
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
 	}))
 	defer srv.Close()
 
-	c := &APIClient{
-		APIEndpoint: srv.URL,
-		APIToken:    "tok",
-		HTTPClient:  srv.Client(),
-	}
-	got, err := c.GetGroupAccess("missing-id")
+	c := &APIClient{APIEndpoint: srv.URL, APIToken: "tok", HTTPClient: srv.Client()}
+	got, err := c.UpdateGroupAccess(GroupAccess{ID: "asg-1", GroupID: "g1", RoleID: "r2"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != nil {
-		t.Fatalf(errFmtTestExpectedNilGot, got)
+	if putBody["id"] != "asg-1" {
+		t.Fatalf("PUT body must carry id, got %+v", putBody)
+	}
+	if got == nil || got.ID != "asg-1" || got.RoleID != "r2" {
+		t.Fatalf("re-read row wrong: %+v", got)
 	}
 }
 
-func TestGetGroupAccess_OK(t *testing.T) {
+func TestUpdateGroupAccess_RequiresID(t *testing.T) {
+	c := &APIClient{APIEndpoint: "http://unused", APIToken: "t", HTTPClient: http.DefaultClient}
+	_, err := c.UpdateGroupAccess(GroupAccess{})
+	if err == nil || !strings.Contains(err.Error(), "id is required") {
+		t.Fatalf("expected id required error, got %v", err)
+	}
+}
+
+// Delete must DELETE the collection path with body {"id": …}; the by-id URL 404s
+// and silently deletes nothing.
+func TestDeleteGroupAccess_UsesBodyNotByID(t *testing.T) {
+	var gotPath, gotMethod string
+	var gotBody map[string]string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/rbac/access/group/asg-1" {
-			t.Fatalf("path %s", r.URL.Path)
-		}
-		_ = json.NewEncoder(w).Encode(groupAccessAPIResponseType{
-			Data: GroupAccess{
-				ID:                "asg-1",
-				GroupID:           "g1",
-				RoleID:            "r1",
-				AllCloudAccounts:  false,
-				UserFilters:       []string{"f1"},
-				CloudAccounts:     []string{},
-				ShiftleftProjects: []string{},
-			},
-		})
+		gotPath, gotMethod = r.URL.Path, r.Method
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "success", "data": map[string]interface{}{}})
 	}))
 	defer srv.Close()
 
-	c := &APIClient{
-		APIEndpoint: srv.URL,
-		APIToken:    "tok",
-		HTTPClient:  srv.Client(),
-	}
-	got, err := c.GetGroupAccess("asg-1")
-	if err != nil {
+	c := &APIClient{APIEndpoint: srv.URL, APIToken: "tok", HTTPClient: srv.Client()}
+	if err := c.DeleteGroupAccess("asg-1"); err != nil {
 		t.Fatal(err)
 	}
-	if got == nil || got.ID != "asg-1" {
-		t.Fatalf(errFmtTestGotValue, got)
+	if gotMethod != http.MethodDelete || gotPath != apiRBACGroupAccessPath {
+		t.Fatalf("expected DELETE %s, got %s %s", apiRBACGroupAccessPath, gotMethod, gotPath)
+	}
+	if gotBody["id"] != "asg-1" {
+		t.Fatalf("expected id in body, got %+v", gotBody)
 	}
 }
 
@@ -220,13 +310,5 @@ func TestDeleteGroupAccess_404Ignored(t *testing.T) {
 	}
 	if err := c.DeleteGroupAccess("gone"); err != nil {
 		t.Fatal(err)
-	}
-}
-
-func TestUpdateGroupAccess_RequiresID(t *testing.T) {
-	c := &APIClient{APIEndpoint: "http://unused", APIToken: "t", HTTPClient: http.DefaultClient}
-	_, err := c.UpdateGroupAccess(GroupAccess{})
-	if err == nil || !strings.Contains(err.Error(), "id is required") {
-		t.Fatalf("expected id required error, got %v", err)
 	}
 }

--- a/orcasecurity/api_client/rbac_access.go
+++ b/orcasecurity/api_client/rbac_access.go
@@ -1,0 +1,322 @@
+package api_client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// The group and user RBAC access endpoints share identical role+scope semantics;
+// only the owner field name (group_id vs user_id), the nested owner key in list
+// rows (group vs user), and the list transport differ. Everything below is the
+// shared engine; group_access.go and user_access.go are thin type-bound wrappers.
+//
+// Neither endpoint exposes a /<id> route (by-id GET/PUT/DELETE 404) — the id
+// travels in the request body, and reads are served by listing the collection.
+//
+// Group access is offset-pageable via OrcaLimitOffsetPaginator (limit +
+// start_at_index query params, server max_limit 300, {total_items,data}
+// envelope). User access is a single unpaginated GET that returns every row and
+// ignores query params.
+const (
+	rbacAccessPageLimit = 300
+	// rbacAccessMaxRows backstops the pagination loop: if the server ever stops
+	// honoring start_at_index it would echo full pages forever, so we abort well
+	// past any realistic assignment count rather than spin.
+	rbacAccessMaxRows = 1_000_000
+)
+
+// rbacAccessEndpoint captures the per-endpoint differences the shared engine
+// needs. ownerKey doubles as the collection label in error messages ("group"
+// access / "user" access).
+type rbacAccessEndpoint struct {
+	path      string
+	ownerKey  string // nested list-row object + payload field stem: "group" | "user"
+	paginated bool
+}
+
+// rbacAccessRecord is the endpoint-agnostic canonical shape the engine operates
+// on. GroupAccess/UserAccess convert to and from it at the package boundary.
+type rbacAccessRecord struct {
+	ID                string
+	AllCloudAccounts  bool
+	RoleID            string
+	OwnerID           string // group id or user id
+	CloudAccounts     []string
+	ShiftleftProjects []string
+	UserFilters       []string
+}
+
+// idRef unwraps the many {"id": "..."} objects the RBAC list rows nest.
+type idRef struct {
+	ID string `json:"id"`
+}
+
+type rbacAccessListRow struct {
+	ID               string          `json:"id"`
+	AllCloudAccounts bool            `json:"all_cloud_accounts"`
+	Group            idRef           `json:"group"`
+	User             idRef           `json:"user"`
+	Role             idRef           `json:"role"`
+	CloudAccounts    []idRef         `json:"cloud_accounts"`
+	UserFilters      []string        `json:"user_filters"`
+	ShiftleftRaw     json.RawMessage `json:"shiftleft_projects"`
+}
+
+func (row rbacAccessListRow) toRecord(ep rbacAccessEndpoint) rbacAccessRecord {
+	ownerID := row.Group.ID
+	if ep.ownerKey == "user" {
+		ownerID = row.User.ID
+	}
+	cloudIDs := make([]string, 0, len(row.CloudAccounts))
+	for _, ca := range row.CloudAccounts {
+		if ca.ID != "" {
+			cloudIDs = append(cloudIDs, ca.ID)
+		}
+	}
+	return rbacAccessRecord{
+		ID:                row.ID,
+		OwnerID:           ownerID,
+		RoleID:            row.Role.ID,
+		AllCloudAccounts:  row.AllCloudAccounts,
+		CloudAccounts:     cloudIDs,
+		ShiftleftProjects: parseShiftleftProjectIDs(row.ShiftleftRaw),
+		UserFilters:       row.UserFilters,
+	}
+}
+
+// rbacAccessWire is the create/update request body. The owner id fields are
+// omitempty so exactly one of group_id/user_id is sent per endpoint.
+type rbacAccessWire struct {
+	ID                string   `json:"id,omitempty"`
+	AllCloudAccounts  bool     `json:"all_cloud_accounts"`
+	RoleID            string   `json:"role_id"`
+	GroupID           string   `json:"group_id,omitempty"`
+	UserID            string   `json:"user_id,omitempty"`
+	CloudAccounts     []string `json:"cloud_accounts"`
+	ShiftleftProjects []string `json:"shiftleft_projects"`
+	UserFilters       []string `json:"user_filters"`
+}
+
+func (r rbacAccessRecord) toWire(ep rbacAccessEndpoint) rbacAccessWire {
+	w := rbacAccessWire{
+		ID:                r.ID,
+		AllCloudAccounts:  r.AllCloudAccounts,
+		RoleID:            r.RoleID,
+		CloudAccounts:     r.CloudAccounts,
+		ShiftleftProjects: r.ShiftleftProjects,
+		UserFilters:       r.UserFilters,
+	}
+	if ep.ownerKey == "user" {
+		w.UserID = r.OwnerID
+	} else {
+		w.GroupID = r.OwnerID
+	}
+	return w
+}
+
+func parseShiftleftProjectIDs(raw json.RawMessage) []string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var strs []string
+	if err := json.Unmarshal(raw, &strs); err == nil {
+		return strs
+	}
+	var objs []idRef
+	if err := json.Unmarshal(raw, &objs); err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(objs))
+	for _, o := range objs {
+		if o.ID != "" {
+			out = append(out, o.ID)
+		}
+	}
+	return out
+}
+
+func normalizeStringSliceForCompare(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	out := append([]string(nil), s...)
+	sort.Strings(out)
+	return out
+}
+
+func stringSliceSetEqual(a, b []string) bool {
+	return slices.Equal(normalizeStringSliceForCompare(a), normalizeStringSliceForCompare(b))
+}
+
+// rbacAccessScopesMatch compares role and scope fields (not assignment id).
+func rbacAccessScopesMatch(want, got rbacAccessRecord) bool {
+	return want.RoleID == got.RoleID &&
+		want.AllCloudAccounts == got.AllCloudAccounts &&
+		stringSliceSetEqual(want.CloudAccounts, got.CloudAccounts) &&
+		stringSliceSetEqual(want.ShiftleftProjects, got.ShiftleftProjects) &&
+		stringSliceSetEqual(want.UserFilters, got.UserFilters)
+}
+
+func pickMatchingAccess(list []rbacAccessRecord, ownerID string, want rbacAccessRecord) *rbacAccessRecord {
+	var matches []rbacAccessRecord
+	for _, item := range list {
+		if item.OwnerID != ownerID {
+			continue
+		}
+		if !rbacAccessScopesMatch(want, item) {
+			continue
+		}
+		matches = append(matches, item)
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	if want.ID != "" {
+		for _, m := range matches {
+			if m.ID == want.ID {
+				picked := m
+				return &picked
+			}
+		}
+	}
+	picked := matches[0]
+	return &picked
+}
+
+// parseAccessID extracts the assignment id from a create/update response,
+// tolerating both the {"data": {...}} envelope and a bare object.
+func parseAccessID(body []byte) string {
+	var envelope struct {
+		Data idRef `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err == nil && envelope.Data.ID != "" {
+		return envelope.Data.ID
+	}
+	var direct idRef
+	if err := json.Unmarshal(body, &direct); err == nil {
+		return direct.ID
+	}
+	return ""
+}
+
+// pageAllAccess returns every assignment in the collection, paging through the
+// offset paginator when the endpoint supports it.
+func (client *APIClient) pageAllAccess(ep rbacAccessEndpoint) ([]rbacAccessRecord, error) {
+	var out []rbacAccessRecord
+	fetched := 0
+	for {
+		path := ep.path
+		if ep.paginated {
+			q := url.Values{}
+			q.Set("limit", strconv.Itoa(rbacAccessPageLimit))
+			q.Set("start_at_index", strconv.Itoa(fetched))
+			path += "?" + q.Encode()
+		}
+		resp, err := client.Get(path)
+		if err != nil {
+			return nil, err
+		}
+		var envelope struct {
+			TotalItems int                 `json:"total_items"`
+			Data       []rbacAccessListRow `json:"data"`
+		}
+		if err := json.Unmarshal(resp.Body(), &envelope); err != nil {
+			return nil, err
+		}
+		for _, row := range envelope.Data {
+			out = append(out, row.toRecord(ep))
+		}
+		fetched += len(envelope.Data)
+		if !ep.paginated || len(envelope.Data) == 0 || fetched >= envelope.TotalItems {
+			return out, nil
+		}
+		if fetched >= rbacAccessMaxRows {
+			return nil, fmt.Errorf(
+				"list %s access: fetched %d rows without reaching total_items=%d; aborting to avoid an unbounded loop (server may be ignoring start_at_index)",
+				ep.ownerKey, fetched, envelope.TotalItems)
+		}
+	}
+}
+
+// listAccessForOwner returns the assignments whose nested owner id equals ownerID.
+func (client *APIClient) listAccessForOwner(ep rbacAccessEndpoint, ownerID string) ([]rbacAccessRecord, error) {
+	all, err := client.pageAllAccess(ep)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]rbacAccessRecord, 0, len(all))
+	for _, r := range all {
+		if r.OwnerID == ownerID {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+// findAccess resolves an assignment by scanning the collection: exact id match
+// first, then role+scope as a fallback for when the id changed server-side.
+func (client *APIClient) findAccess(ep rbacAccessEndpoint, assignmentID string, want rbacAccessRecord) (*rbacAccessRecord, error) {
+	list, err := client.pageAllAccess(ep)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range list {
+		if item.ID == assignmentID {
+			picked := item
+			return &picked, nil
+		}
+	}
+	// Fallback: the id changed server-side (Orca merged or recreated the row).
+	// Match by owner+role+scope instead. NOTE: with no by-id route to confirm a
+	// deletion, this can adopt a sibling row of identical scope if the original
+	// was truly deleted — that trade-off is deliberate; do not "fix" it into a
+	// recreate, which is the re-creation bug WASP-1494 removed.
+	want.ID = assignmentID
+	return pickMatchingAccess(list, want.OwnerID, want), nil
+}
+
+func (client *APIClient) createAccess(ep rbacAccessEndpoint, rec rbacAccessRecord) (string, error) {
+	resp, err := client.Post(ep.path, rec.toWire(ep))
+	if err != nil {
+		return "", err
+	}
+	id := parseAccessID(resp.Body())
+	if id == "" {
+		return "", fmt.Errorf("create %s access: could not parse assignment id from response: %s", ep.ownerKey, string(resp.Body()))
+	}
+	return id, nil
+}
+
+// updateAccess PUTs the assignment (id in the body) then re-reads the canonical
+// row, since the PUT response nests owner/role rather than returning the flat shape.
+func (client *APIClient) updateAccess(ep rbacAccessEndpoint, rec rbacAccessRecord) (*rbacAccessRecord, error) {
+	if rec.ID == "" {
+		return nil, fmt.Errorf("update %s access: id is required", ep.ownerKey)
+	}
+	if _, err := client.Put(ep.path, rec.toWire(ep)); err != nil {
+		return nil, err
+	}
+	refreshed, err := client.findAccess(ep, rec.ID, rec)
+	if err != nil {
+		return nil, err
+	}
+	if refreshed != nil {
+		return refreshed, nil
+	}
+	return &rec, nil
+}
+
+// deleteAccess removes an assignment (id carried in the body); a 404 is treated
+// as already-gone.
+func (client *APIClient) deleteAccess(ep rbacAccessEndpoint, id string) error {
+	_, err := client.DeleteWithBody(ep.path, map[string]string{"id": id})
+	if err != nil && strings.Contains(err.Error(), "status: 404") {
+		return nil
+	}
+	return err
+}

--- a/orcasecurity/api_client/user_access.go
+++ b/orcasecurity/api_client/user_access.go
@@ -1,209 +1,98 @@
 package api_client
 
-import (
-	"encoding/json"
-	"fmt"
-	"net/url"
-	"strconv"
-	"strings"
-)
-
-// No /<id> route: id in body. User list is one-shot (ignores pagination params).
 const apiRBACUserAccessPath = "/api/rbac/access/user"
 
+var userAccessEndpoint = rbacAccessEndpoint{
+	path:     apiRBACUserAccessPath,
+	ownerKey: "user",
+	// The user endpoint is a single unpaginated GET that returns every row and
+	// ignores query params — do not send limit/start_at_index.
+	paginated: false,
+}
+
+// UserAccess is the public DTO for a user–role assignment. The shared engine in
+// rbac_access.go does the transport; this type just names the user-facing fields
+// the resource layer reads.
 type UserAccess struct {
-	ID                string   `json:"id,omitempty"`
-	AllCloudAccounts  bool     `json:"all_cloud_accounts"`
-	RoleID            string   `json:"role_id"`
-	UserID            string   `json:"user_id"`
-	CloudAccounts     []string `json:"cloud_accounts"`
-	ShiftleftProjects []string `json:"shiftleft_projects"`
-	UserFilters       []string `json:"user_filters"`
+	ID                string
+	AllCloudAccounts  bool
+	RoleID            string
+	UserID            string
+	CloudAccounts     []string
+	ShiftleftProjects []string
+	UserFilters       []string
 }
 
-type userAccessListRow struct {
-	ID               string          `json:"id"`
-	AllCloudAccounts bool            `json:"all_cloud_accounts"`
-	User             userAccessRef   `json:"user"`
-	Role             userAccessRef   `json:"role"`
-	CloudAccounts    []userAccessRef `json:"cloud_accounts"`
-	UserFilters      []string        `json:"user_filters"`
-	ShiftleftRaw     json.RawMessage `json:"shiftleft_projects"`
-}
-
-type userAccessRef struct {
-	ID string `json:"id"`
-}
-
-func userAccessFromListRow(row userAccessListRow) UserAccess {
-	cloudIDs := make([]string, 0, len(row.CloudAccounts))
-	for _, ca := range row.CloudAccounts {
-		if ca.ID != "" {
-			cloudIDs = append(cloudIDs, ca.ID)
-		}
+func (u UserAccess) toRecord() rbacAccessRecord {
+	return rbacAccessRecord{
+		ID:                u.ID,
+		OwnerID:           u.UserID,
+		RoleID:            u.RoleID,
+		AllCloudAccounts:  u.AllCloudAccounts,
+		CloudAccounts:     u.CloudAccounts,
+		ShiftleftProjects: u.ShiftleftProjects,
+		UserFilters:       u.UserFilters,
 	}
+}
+
+func userAccessFromRecord(r rbacAccessRecord) UserAccess {
 	return UserAccess{
-		ID:                row.ID,
-		UserID:            row.User.ID,
-		RoleID:            row.Role.ID,
-		AllCloudAccounts:  row.AllCloudAccounts,
-		CloudAccounts:     cloudIDs,
-		ShiftleftProjects: parseShiftleftProjectIDs(row.ShiftleftRaw),
-		UserFilters:       row.UserFilters,
+		ID:                r.ID,
+		UserID:            r.OwnerID,
+		RoleID:            r.RoleID,
+		AllCloudAccounts:  r.AllCloudAccounts,
+		CloudAccounts:     r.CloudAccounts,
+		ShiftleftProjects: r.ShiftleftProjects,
+		UserFilters:       r.UserFilters,
 	}
-}
-
-// parseUserAccessID extracts the assignment id from a create/update response,
-// tolerating both the {"data": {...}} envelope and a bare object.
-func parseUserAccessID(body []byte) string {
-	var envelope struct {
-		Data struct {
-			ID string `json:"id"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(body, &envelope); err == nil && envelope.Data.ID != "" {
-		return envelope.Data.ID
-	}
-	var direct struct {
-		ID string `json:"id"`
-	}
-	if err := json.Unmarshal(body, &direct); err == nil {
-		return direct.ID
-	}
-	return ""
 }
 
 // CreateUserAccess assigns a role to a user with optional cloud account, Shift
 // Left, or user filter (e.g. business unit) scope.
 func (client *APIClient) CreateUserAccess(data UserAccess) (*UserAccess, error) {
-	resp, err := client.Post(apiRBACUserAccessPath, data)
+	id, err := client.createAccess(userAccessEndpoint, data.toRecord())
 	if err != nil {
 		return nil, err
-	}
-	id := parseUserAccessID(resp.Body())
-	if id == "" {
-		return nil, fmt.Errorf("create user access: could not parse assignment id from response: %s", string(resp.Body()))
 	}
 	out := data
 	out.ID = id
 	return &out, nil
 }
 
-func (client *APIClient) pageAllUserAccess() ([]UserAccess, error) {
-	q := url.Values{}
-	q.Set("limit", strconv.Itoa(rbacAccessMaxLimit))
-	resp, err := client.Get(apiRBACUserAccessPath + "?" + q.Encode())
-	if err != nil {
-		return nil, err
-	}
-	var envelope struct {
-		Data []userAccessListRow `json:"data"`
-	}
-	if err := json.Unmarshal(resp.Body(), &envelope); err != nil {
-		return nil, err
-	}
-	out := make([]UserAccess, 0, len(envelope.Data))
-	for _, row := range envelope.Data {
-		out = append(out, userAccessFromListRow(row))
-	}
-	return out, nil
-}
-
 // ListUserAccessForUser returns the assignments whose nested user id equals userID.
 func (client *APIClient) ListUserAccessForUser(userID string) ([]UserAccess, error) {
-	all, err := client.pageAllUserAccess()
+	records, err := client.listAccessForOwner(userAccessEndpoint, userID)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]UserAccess, 0, len(all))
-	for _, ua := range all {
-		if ua.UserID == userID {
-			out = append(out, ua)
-		}
+	out := make([]UserAccess, 0, len(records))
+	for _, r := range records {
+		out = append(out, userAccessFromRecord(r))
 	}
 	return out, nil
 }
 
-// userAccessScopesMatch compares role and scope fields (not assignment id).
-func userAccessScopesMatch(want, got UserAccess) bool {
-	return want.RoleID == got.RoleID &&
-		want.AllCloudAccounts == got.AllCloudAccounts &&
-		stringSliceSetEqual(want.CloudAccounts, got.CloudAccounts) &&
-		stringSliceSetEqual(want.ShiftleftProjects, got.ShiftleftProjects) &&
-		stringSliceSetEqual(want.UserFilters, got.UserFilters)
-}
-
-func pickMatchingUserAccess(list []UserAccess, userID string, want UserAccess) *UserAccess {
-	var matches []UserAccess
-	for _, item := range list {
-		if item.UserID != userID {
-			continue
-		}
-		if !userAccessScopesMatch(want, item) {
-			continue
-		}
-		matches = append(matches, item)
-	}
-	if len(matches) == 0 {
-		return nil
-	}
-	if want.ID != "" {
-		for _, m := range matches {
-			if m.ID == want.ID {
-				picked := m
-				return &picked
-			}
-		}
-	}
-	picked := matches[0]
-	return &picked
-}
-
+// FindUserAccess resolves an assignment by id (preferred) or role+scope fallback; nil when nothing matches.
 func (client *APIClient) FindUserAccess(assignmentID string, want UserAccess) (*UserAccess, error) {
-	var list []UserAccess
-	var err error
-	if want.UserID == "" {
-		list, err = client.pageAllUserAccess()
-	} else {
-		list, err = client.ListUserAccessForUser(want.UserID)
-	}
-	if err != nil {
+	rec, err := client.findAccess(userAccessEndpoint, assignmentID, want.toRecord())
+	if err != nil || rec == nil {
 		return nil, err
 	}
-	for _, item := range list {
-		if item.ID == assignmentID {
-			picked := item
-			return &picked, nil
-		}
-	}
-	want.ID = assignmentID
-	return pickMatchingUserAccess(list, want.UserID, want), nil
+	out := userAccessFromRecord(*rec)
+	return &out, nil
 }
 
-// UpdateUserAccess updates an existing assignment. The id is carried in the body.
+// UpdateUserAccess updates an existing assignment (id carried in the body).
 func (client *APIClient) UpdateUserAccess(data UserAccess) (*UserAccess, error) {
-	if data.ID == "" {
-		return nil, fmt.Errorf("update user access: id is required")
-	}
-	if _, err := client.Put(apiRBACUserAccessPath, data); err != nil {
-		return nil, err
-	}
-	refreshed, err := client.FindUserAccess(data.ID, data)
+	rec, err := client.updateAccess(userAccessEndpoint, data.toRecord())
 	if err != nil {
 		return nil, err
 	}
-	if refreshed != nil {
-		return refreshed, nil
-	}
-	out := data
+	out := userAccessFromRecord(*rec)
 	return &out, nil
 }
 
 // DeleteUserAccess removes a user–role assignment (id carried in the body).
 func (client *APIClient) DeleteUserAccess(id string) error {
-	_, err := client.DeleteWithBody(apiRBACUserAccessPath, map[string]string{"id": id})
-	if err != nil && strings.Contains(err.Error(), "status: 404") {
-		return nil
-	}
-	return err
+	return client.deleteAccess(userAccessEndpoint, id)
 }

--- a/orcasecurity/api_client/user_access.go
+++ b/orcasecurity/api_client/user_access.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -90,11 +91,14 @@ func (client *APIClient) CreateUserAccess(data UserAccess) (*UserAccess, error) 
 	return &out, nil
 }
 
-// ListUserAccessForUser calls GET /api/rbac/access/user?user_id=… and returns the
-// rows whose nested user id equals userID (the API may include other users).
-func (client *APIClient) ListUserAccessForUser(userID string) ([]UserAccess, error) {
+// pageAllUserAccess returns the whole /api/rbac/access/user collection. Unlike
+// the group endpoint, this one ignores user_id, limit and start_at_index and
+// carries no total_items, returning every row in a single response. A high
+// limit is sent only as insurance against a future server-side page cap; the
+// rows are filtered client-side by the caller.
+func (client *APIClient) pageAllUserAccess() ([]UserAccess, error) {
 	q := url.Values{}
-	q.Set("user_id", userID)
+	q.Set("limit", strconv.Itoa(rbacAccessMaxLimit))
 	resp, err := client.Get(apiRBACUserAccessPath + "?" + q.Encode())
 	if err != nil {
 		return nil, err
@@ -107,11 +111,22 @@ func (client *APIClient) ListUserAccessForUser(userID string) ([]UserAccess, err
 	}
 	out := make([]UserAccess, 0, len(envelope.Data))
 	for _, row := range envelope.Data {
-		ua := userAccessFromListRow(row)
-		if ua.UserID != userID {
-			continue
+		out = append(out, userAccessFromListRow(row))
+	}
+	return out, nil
+}
+
+// ListUserAccessForUser returns the assignments whose nested user id equals userID.
+func (client *APIClient) ListUserAccessForUser(userID string) ([]UserAccess, error) {
+	all, err := client.pageAllUserAccess()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]UserAccess, 0, len(all))
+	for _, ua := range all {
+		if ua.UserID == userID {
+			out = append(out, ua)
 		}
-		out = append(out, ua)
 	}
 	return out, nil
 }
@@ -151,14 +166,18 @@ func pickMatchingUserAccess(list []UserAccess, userID string, want UserAccess) *
 	return &picked
 }
 
-// FindUserAccess resolves an assignment by listing the user's assignments and
-// returning the row matching id (preferred) or role+scope (as a fallback when
-// the id has changed server-side). Returns nil when nothing matches.
+// FindUserAccess returns the assignment matching id (preferred) or role+scope
+// (fallback when the id has changed server-side). When want.UserID is unset
+// (import, where only the id is known) it scans the whole collection. Returns
+// nil when nothing matches.
 func (client *APIClient) FindUserAccess(assignmentID string, want UserAccess) (*UserAccess, error) {
+	var list []UserAccess
+	var err error
 	if want.UserID == "" {
-		return nil, nil
+		list, err = client.pageAllUserAccess()
+	} else {
+		list, err = client.ListUserAccessForUser(want.UserID)
 	}
-	list, err := client.ListUserAccessForUser(want.UserID)
 	if err != nil {
 		return nil, err
 	}

--- a/orcasecurity/api_client/user_access.go
+++ b/orcasecurity/api_client/user_access.go
@@ -8,9 +8,7 @@ import (
 	"strings"
 )
 
-// UserAccess maps to the POST/PUT/DELETE /api/rbac/access/user payloads. Unlike
-// the group variant, this endpoint has no /<id> route: the record id travels in
-// the request body, and reads are served by listing the collection.
+// No /<id> route: id in body. User list is one-shot (ignores pagination params).
 const apiRBACUserAccessPath = "/api/rbac/access/user"
 
 type UserAccess struct {
@@ -91,11 +89,6 @@ func (client *APIClient) CreateUserAccess(data UserAccess) (*UserAccess, error) 
 	return &out, nil
 }
 
-// pageAllUserAccess returns the whole /api/rbac/access/user collection. Unlike
-// the group endpoint, this one ignores user_id, limit and start_at_index and
-// carries no total_items, returning every row in a single response. A high
-// limit is sent only as insurance against a future server-side page cap; the
-// rows are filtered client-side by the caller.
 func (client *APIClient) pageAllUserAccess() ([]UserAccess, error) {
 	q := url.Values{}
 	q.Set("limit", strconv.Itoa(rbacAccessMaxLimit))
@@ -166,10 +159,6 @@ func pickMatchingUserAccess(list []UserAccess, userID string, want UserAccess) *
 	return &picked
 }
 
-// FindUserAccess returns the assignment matching id (preferred) or role+scope
-// (fallback when the id has changed server-side). When want.UserID is unset
-// (import, where only the id is known) it scans the whole collection. Returns
-// nil when nothing matches.
 func (client *APIClient) FindUserAccess(assignmentID string, want UserAccess) (*UserAccess, error) {
 	var list []UserAccess
 	var err error
@@ -181,7 +170,6 @@ func (client *APIClient) FindUserAccess(assignmentID string, want UserAccess) (*
 	if err != nil {
 		return nil, err
 	}
-	// Exact id match first.
 	for _, item := range list {
 		if item.ID == assignmentID {
 			picked := item
@@ -200,7 +188,6 @@ func (client *APIClient) UpdateUserAccess(data UserAccess) (*UserAccess, error) 
 	if _, err := client.Put(apiRBACUserAccessPath, data); err != nil {
 		return nil, err
 	}
-	// The PUT response nests user/role; re-read the canonical row instead.
 	refreshed, err := client.FindUserAccess(data.ID, data)
 	if err != nil {
 		return nil, err

--- a/orcasecurity/api_client/user_access_test.go
+++ b/orcasecurity/api_client/user_access_test.go
@@ -90,8 +90,8 @@ func TestFindUserAccess(t *testing.T) {
 		if req.Method != "GET" {
 			t.Errorf("expected GET, got %s", req.Method)
 		}
-		if req.URL.Query().Get("user_id") != testUserAccessUserID {
-			t.Errorf("expected user_id query, got %s", req.URL.RawQuery)
+		if req.URL.Query().Get("limit") == "" {
+			t.Errorf("expected a paginated list request, got %s", req.URL.RawQuery)
 		}
 		return &http.Response{
 			StatusCode: 200,
@@ -110,6 +110,57 @@ func TestFindUserAccess(t *testing.T) {
 	}
 	if ua.ID != testUserAccessID || ua.RoleID != testUserAccessRoleID || !ua.AllCloudAccounts {
 		t.Errorf("unexpected assignment: %+v", ua)
+	}
+}
+
+// The user endpoint returns the whole collection in one response (it ignores
+// user_id/limit/start_at_index and carries no total_items); the client fetches
+// once with a high limit and filters by nested user id.
+func TestListUserAccessForUser_FetchesAllInOneRequest(t *testing.T) {
+	requests := 0
+	httpClient := &http.Client{Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+		requests++
+		if req.URL.Query().Get("limit") == "" {
+			t.Errorf("expected a high limit to be sent")
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(testUserAccessListResponse)),
+			Request:    req,
+		}
+	})}
+
+	apiClient := newTestAPIClient(httpClient)
+	got, err := apiClient.ListUserAccessForUser(testUserAccessUserID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("expected a single request (endpoint is not offset-pageable), got %d", requests)
+	}
+	if len(got) != 1 || got[0].ID != testUserAccessID {
+		t.Fatalf("expected the user's row filtered from the collection, got %+v", got)
+	}
+}
+
+// On import only the id is known (want.UserID empty); Find must scan the whole
+// collection and still resolve the grant.
+func TestFindUserAccess_ScansAllWhenUserUnknown(t *testing.T) {
+	httpClient := &http.Client{Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(testUserAccessListResponse)),
+			Request:    req,
+		}
+	})}
+
+	apiClient := newTestAPIClient(httpClient)
+	ua, err := apiClient.FindUserAccess(testUserAccessID, UserAccess{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ua == nil || ua.ID != testUserAccessID || ua.UserID != testUserAccessUserID {
+		t.Fatalf("expected imported assignment, got %+v", ua)
 	}
 }
 

--- a/orcasecurity/api_client/user_access_test.go
+++ b/orcasecurity/api_client/user_access_test.go
@@ -90,8 +90,8 @@ func TestFindUserAccess(t *testing.T) {
 		if req.Method != "GET" {
 			t.Errorf("expected GET, got %s", req.Method)
 		}
-		if req.URL.Query().Get("limit") == "" {
-			t.Errorf("expected a paginated list request, got %s", req.URL.RawQuery)
+		if req.URL.RawQuery != "" {
+			t.Errorf("user endpoint is one-shot; expected no query params, got %s", req.URL.RawQuery)
 		}
 		return &http.Response{
 			StatusCode: 200,
@@ -118,8 +118,8 @@ func TestListUserAccessForUser_FetchesAllInOneRequest(t *testing.T) {
 	requests := 0
 	httpClient := &http.Client{Transport: RoundTripFunc(func(req *http.Request) *http.Response {
 		requests++
-		if req.URL.Query().Get("limit") == "" {
-			t.Errorf("expected a high limit to be sent")
+		if req.URL.RawQuery != "" {
+			t.Errorf("user endpoint ignores pagination params; expected none, got %s", req.URL.RawQuery)
 		}
 		return &http.Response{
 			StatusCode: 200,

--- a/orcasecurity/api_client/user_access_test.go
+++ b/orcasecurity/api_client/user_access_test.go
@@ -113,9 +113,7 @@ func TestFindUserAccess(t *testing.T) {
 	}
 }
 
-// The user endpoint returns the whole collection in one response (it ignores
-// user_id/limit/start_at_index and carries no total_items); the client fetches
-// once with a high limit and filters by nested user id.
+// User list is one-shot; filter client-side by nested user id.
 func TestListUserAccessForUser_FetchesAllInOneRequest(t *testing.T) {
 	requests := 0
 	httpClient := &http.Client{Transport: RoundTripFunc(func(req *http.Request) *http.Response {
@@ -143,8 +141,7 @@ func TestListUserAccessForUser_FetchesAllInOneRequest(t *testing.T) {
 	}
 }
 
-// On import only the id is known (want.UserID empty); Find must scan the whole
-// collection and still resolve the grant.
+// Import: only assignment id known — scan whole collection.
 func TestFindUserAccess_ScansAllWhenUserUnknown(t *testing.T) {
 	httpClient := &http.Client{Transport: RoundTripFunc(func(req *http.Request) *http.Response {
 		return &http.Response{

--- a/orcasecurity/group_access/resource_acceptance_test.go
+++ b/orcasecurity/group_access/resource_acceptance_test.go
@@ -14,9 +14,6 @@ import (
 
 const testAccGroupAccessResourceName = "orcasecurity_group_access.acc"
 
-// testAccGroupAccessClient builds an API client from the acceptance env vars so
-// CheckDestroy can confirm a grant is actually gone (the by-id DELETE used to
-// 404 and silently delete nothing).
 func testAccGroupAccessClient(t *testing.T) *api_client.APIClient {
 	t.Helper()
 	endpoint := os.Getenv("ORCASECURITY_API_ENDPOINT")
@@ -28,8 +25,6 @@ func testAccGroupAccessClient(t *testing.T) *api_client.APIClient {
 	return c
 }
 
-// testAccCheckGroupAccessDestroyed lists the group's live assignments and fails
-// if the tracked id is still present after destroy.
 func testAccCheckGroupAccessDestroyed(t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[testAccGroupAccessResourceName]
@@ -72,8 +67,6 @@ resource "orcasecurity_group_access" "acc" {
 	}
 
 	steps := []resource.TestStep{
-		// Create. A clean plan after apply proves the read path resolves the
-		// grant instead of dropping it and planning a re-create.
 		{
 			Config: cfg(fid),
 			Check: resource.ComposeAggregateTestCheckFunc(
@@ -84,7 +77,6 @@ resource "orcasecurity_group_access" "acc" {
 				resource.TestCheckResourceAttrSet(testAccGroupAccessResourceName, "id"),
 			),
 		},
-		// Import round-trips through the list-and-filter read.
 		{
 			ResourceName:      testAccGroupAccessResourceName,
 			ImportState:       true,
@@ -92,9 +84,7 @@ resource "orcasecurity_group_access" "acc" {
 		},
 	}
 
-	// In-place update (swap the scoped filter) exercises the collection-path PUT.
-	// Needs a second filter id; all_cloud_accounts and the scope lists are
-	// mutually exclusive server-side, so the update stays within one scope type.
+	// Optional update step; set ORCASECURITY_ACC_GROUP_ACCESS_USER_FILTER_ID_2.
 	if fid2 := os.Getenv("ORCASECURITY_ACC_GROUP_ACCESS_USER_FILTER_ID_2"); fid2 != "" {
 		steps = append(steps, resource.TestStep{
 			Config: cfg(fid2),

--- a/orcasecurity/group_access/resource_acceptance_test.go
+++ b/orcasecurity/group_access/resource_acceptance_test.go
@@ -6,11 +6,50 @@ import (
 	"testing"
 
 	"terraform-provider-orcasecurity/orcasecurity"
+	"terraform-provider-orcasecurity/orcasecurity/api_client"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testAccGroupAccessResourceName = "orcasecurity_group_access.acc"
+
+// testAccGroupAccessClient builds an API client from the acceptance env vars so
+// CheckDestroy can confirm a grant is actually gone (the by-id DELETE used to
+// 404 and silently delete nothing).
+func testAccGroupAccessClient(t *testing.T) *api_client.APIClient {
+	t.Helper()
+	endpoint := os.Getenv("ORCASECURITY_API_ENDPOINT")
+	token := os.Getenv("ORCASECURITY_API_TOKEN")
+	c, err := api_client.NewAPIClient(&endpoint, &token)
+	if err != nil {
+		t.Fatalf("build api client: %s", err)
+	}
+	return c
+}
+
+// testAccCheckGroupAccessDestroyed lists the group's live assignments and fails
+// if the tracked id is still present after destroy.
+func testAccCheckGroupAccessDestroyed(t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[testAccGroupAccessResourceName]
+		if !ok {
+			return nil // never created
+		}
+		id := rs.Primary.ID
+		groupID := rs.Primary.Attributes["group_id"]
+		list, err := testAccGroupAccessClient(t).ListGroupAccessForGroup(groupID)
+		if err != nil {
+			return fmt.Errorf("verifying destroy: %s", err)
+		}
+		for _, ga := range list {
+			if ga.ID == id {
+				return fmt.Errorf("group access %s still exists after destroy", id)
+			}
+		}
+		return nil
+	}
+}
 
 func TestAccGroupAccess_envIDs(t *testing.T) {
 	gid := os.Getenv("ORCASECURITY_ACC_GROUP_ACCESS_GROUP_ID")
@@ -20,30 +59,57 @@ func TestAccGroupAccess_envIDs(t *testing.T) {
 		t.Skip("Skipping: set ORCASECURITY_ACC_GROUP_ACCESS_GROUP_ID, ORCASECURITY_ACC_GROUP_ACCESS_ROLE_ID, and ORCASECURITY_ACC_GROUP_ACCESS_USER_FILTER_ID to run this acceptance test")
 	}
 
-	cfg := fmt.Sprintf(`
+	cfg := func(filterID string) string {
+		return fmt.Sprintf(`
 %s
 resource "orcasecurity_group_access" "acc" {
-  group_id             = %q
-  role_id              = %q
-  all_cloud_accounts   = false
-  user_filters         = [%q]
+  group_id           = %q
+  role_id            = %q
+  all_cloud_accounts = false
+  user_filters       = [%q]
 }
-`, orcasecurity.TestProviderConfig, gid, rid, fid)
+`, orcasecurity.TestProviderConfig, gid, rid, filterID)
+	}
+
+	steps := []resource.TestStep{
+		// Create. A clean plan after apply proves the read path resolves the
+		// grant instead of dropping it and planning a re-create.
+		{
+			Config: cfg(fid),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(testAccGroupAccessResourceName, "group_id", gid),
+				resource.TestCheckResourceAttr(testAccGroupAccessResourceName, "role_id", rid),
+				resource.TestCheckResourceAttr(testAccGroupAccessResourceName, "user_filters.#", "1"),
+				resource.TestCheckResourceAttr(testAccGroupAccessResourceName, "user_filters.0", fid),
+				resource.TestCheckResourceAttrSet(testAccGroupAccessResourceName, "id"),
+			),
+		},
+		// Import round-trips through the list-and-filter read.
+		{
+			ResourceName:      testAccGroupAccessResourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+		},
+	}
+
+	// In-place update (swap the scoped filter) exercises the collection-path PUT.
+	// Needs a second filter id; all_cloud_accounts and the scope lists are
+	// mutually exclusive server-side, so the update stays within one scope type.
+	if fid2 := os.Getenv("ORCASECURITY_ACC_GROUP_ACCESS_USER_FILTER_ID_2"); fid2 != "" {
+		steps = append(steps, resource.TestStep{
+			Config: cfg(fid2),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(testAccGroupAccessResourceName, "user_filters.#", "1"),
+				resource.TestCheckResourceAttr(testAccGroupAccessResourceName, "user_filters.0", fid2),
+				resource.TestCheckResourceAttrSet(testAccGroupAccessResourceName, "id"),
+			),
+		})
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { orcasecurity.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: orcasecurity.TestAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: cfg,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(testAccGroupAccessResourceName, "group_id", gid),
-					resource.TestCheckResourceAttr(testAccGroupAccessResourceName, "role_id", rid),
-					resource.TestCheckResourceAttr(testAccGroupAccessResourceName, "user_filters.#", "1"),
-					resource.TestCheckResourceAttr(testAccGroupAccessResourceName, "user_filters.0", fid),
-					resource.TestCheckResourceAttrSet(testAccGroupAccessResourceName, "id"),
-				),
-			},
-		},
+		CheckDestroy:             testAccCheckGroupAccessDestroyed(t),
+		Steps:                    steps,
 	})
 }

--- a/orcasecurity/user_access/resource_acceptance_test.go
+++ b/orcasecurity/user_access/resource_acceptance_test.go
@@ -1,0 +1,114 @@
+package user_access_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"terraform-provider-orcasecurity/orcasecurity"
+	"terraform-provider-orcasecurity/orcasecurity/api_client"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+const testAccUserAccessResourceName = "orcasecurity_user_access.acc"
+
+// testAccUserAccessClient builds an API client from the acceptance env vars so
+// CheckDestroy can confirm a grant is actually gone.
+func testAccUserAccessClient(t *testing.T) *api_client.APIClient {
+	t.Helper()
+	endpoint := os.Getenv("ORCASECURITY_API_ENDPOINT")
+	token := os.Getenv("ORCASECURITY_API_TOKEN")
+	c, err := api_client.NewAPIClient(&endpoint, &token)
+	if err != nil {
+		t.Fatalf("build api client: %s", err)
+	}
+	return c
+}
+
+// testAccCheckUserAccessDestroyed lists the user's live assignments and fails if
+// the tracked id is still present after destroy.
+func testAccCheckUserAccessDestroyed(t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[testAccUserAccessResourceName]
+		if !ok {
+			return nil // never created
+		}
+		id := rs.Primary.ID
+		userID := rs.Primary.Attributes["user_id"]
+		list, err := testAccUserAccessClient(t).ListUserAccessForUser(userID)
+		if err != nil {
+			return fmt.Errorf("verifying destroy: %s", err)
+		}
+		for _, ua := range list {
+			if ua.ID == id {
+				return fmt.Errorf("user access %s still exists after destroy", id)
+			}
+		}
+		return nil
+	}
+}
+
+func TestAccUserAccess_envIDs(t *testing.T) {
+	uid := os.Getenv("ORCASECURITY_ACC_USER_ACCESS_USER_ID")
+	rid := os.Getenv("ORCASECURITY_ACC_USER_ACCESS_ROLE_ID")
+	fid := os.Getenv("ORCASECURITY_ACC_USER_ACCESS_USER_FILTER_ID")
+	if uid == "" || rid == "" || fid == "" {
+		t.Skip("Skipping: set ORCASECURITY_ACC_USER_ACCESS_USER_ID, ORCASECURITY_ACC_USER_ACCESS_ROLE_ID, and ORCASECURITY_ACC_USER_ACCESS_USER_FILTER_ID to run this acceptance test")
+	}
+
+	cfg := func(filterID string) string {
+		return fmt.Sprintf(`
+%s
+resource "orcasecurity_user_access" "acc" {
+  user_id            = %q
+  role_id            = %q
+  all_cloud_accounts = false
+  user_filters       = [%q]
+}
+`, orcasecurity.TestProviderConfig, uid, rid, filterID)
+	}
+
+	steps := []resource.TestStep{
+		// Create. A clean plan after apply proves the read path resolves the
+		// grant instead of dropping it and planning a re-create.
+		{
+			Config: cfg(fid),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(testAccUserAccessResourceName, "user_id", uid),
+				resource.TestCheckResourceAttr(testAccUserAccessResourceName, "role_id", rid),
+				resource.TestCheckResourceAttr(testAccUserAccessResourceName, "user_filters.#", "1"),
+				resource.TestCheckResourceAttr(testAccUserAccessResourceName, "user_filters.0", fid),
+				resource.TestCheckResourceAttrSet(testAccUserAccessResourceName, "id"),
+			),
+		},
+		// Import round-trips through the list-and-filter read.
+		{
+			ResourceName:      testAccUserAccessResourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+		},
+	}
+
+	// In-place update (swap the scoped filter) exercises the collection-path PUT.
+	// Needs a second filter id; all_cloud_accounts and the scope lists are
+	// mutually exclusive server-side, so the update stays within one scope type.
+	if fid2 := os.Getenv("ORCASECURITY_ACC_USER_ACCESS_USER_FILTER_ID_2"); fid2 != "" {
+		steps = append(steps, resource.TestStep{
+			Config: cfg(fid2),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(testAccUserAccessResourceName, "user_filters.#", "1"),
+				resource.TestCheckResourceAttr(testAccUserAccessResourceName, "user_filters.0", fid2),
+				resource.TestCheckResourceAttrSet(testAccUserAccessResourceName, "id"),
+			),
+		})
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { orcasecurity.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: orcasecurity.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckUserAccessDestroyed(t),
+		Steps:                    steps,
+	})
+}

--- a/orcasecurity/user_access/resource_acceptance_test.go
+++ b/orcasecurity/user_access/resource_acceptance_test.go
@@ -14,8 +14,6 @@ import (
 
 const testAccUserAccessResourceName = "orcasecurity_user_access.acc"
 
-// testAccUserAccessClient builds an API client from the acceptance env vars so
-// CheckDestroy can confirm a grant is actually gone.
 func testAccUserAccessClient(t *testing.T) *api_client.APIClient {
 	t.Helper()
 	endpoint := os.Getenv("ORCASECURITY_API_ENDPOINT")
@@ -27,8 +25,6 @@ func testAccUserAccessClient(t *testing.T) *api_client.APIClient {
 	return c
 }
 
-// testAccCheckUserAccessDestroyed lists the user's live assignments and fails if
-// the tracked id is still present after destroy.
 func testAccCheckUserAccessDestroyed(t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[testAccUserAccessResourceName]
@@ -71,8 +67,6 @@ resource "orcasecurity_user_access" "acc" {
 	}
 
 	steps := []resource.TestStep{
-		// Create. A clean plan after apply proves the read path resolves the
-		// grant instead of dropping it and planning a re-create.
 		{
 			Config: cfg(fid),
 			Check: resource.ComposeAggregateTestCheckFunc(
@@ -83,7 +77,6 @@ resource "orcasecurity_user_access" "acc" {
 				resource.TestCheckResourceAttrSet(testAccUserAccessResourceName, "id"),
 			),
 		},
-		// Import round-trips through the list-and-filter read.
 		{
 			ResourceName:      testAccUserAccessResourceName,
 			ImportState:       true,
@@ -91,9 +84,7 @@ resource "orcasecurity_user_access" "acc" {
 		},
 	}
 
-	// In-place update (swap the scoped filter) exercises the collection-path PUT.
-	// Needs a second filter id; all_cloud_accounts and the scope lists are
-	// mutually exclusive server-side, so the update stays within one scope type.
+	// Optional update step; set ORCASECURITY_ACC_USER_ACCESS_USER_FILTER_ID_2.
 	if fid2 := os.Getenv("ORCASECURITY_ACC_USER_ACCESS_USER_FILTER_ID_2"); fid2 != "" {
 		steps = append(steps, resource.TestStep{
 			Config: cfg(fid2),

--- a/templates/resources/user_access.md.tmpl
+++ b/templates/resources/user_access.md.tmpl
@@ -21,3 +21,9 @@ This is the per-user counterpart of `orcasecurity_group_access`. To invite a new
 {{tffile "examples/resources/orcasecurity_user_access/resource.tf"}}
 
 {{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+Import is supported using the following syntax. The id is the Orca assignment id (the `id` attribute of the resource).
+
+{{codefile "shell" "examples/resources/orcasecurity_user_access/import.sh"}}

--- a/templates/resources/user_access.md.tmpl
+++ b/templates/resources/user_access.md.tmpl
@@ -24,6 +24,6 @@ This is the per-user counterpart of `orcasecurity_group_access`. To invite a new
 
 ## Import
 
-Import is supported using the following syntax. The id is the Orca assignment id (the `id` attribute of the resource).
+Import is supported using the following syntax (id = Orca assignment id):
 
 {{codefile "shell" "examples/resources/orcasecurity_user_access/import.sh"}}


### PR DESCRIPTION
## Summary

Fixes #261. `orcasecurity_group_access` and `orcasecurity_user_access` were re-created on every apply and destroy was a silent no-op.

## Root cause

- No `/<id>` route — id goes in the request body; reads list-and-filter client-side.
- Group list paginates (default 10); user list returns everything in one response (not offset-pageable).

## Changes

- Page full group collection; single high-limit fetch for user list.
- PUT/DELETE on collection path with id in body; import scans by assignment id.
- Import docs + acceptance tests with CheckDestroy.

## Test plan

- [x] Unit tests (`api_client/group_access`, `api_client/user_access`)
- [x] Acceptance tests pass live (create → import → update → destroy)